### PR TITLE
🧹 Remove commented out code in js/ambient/ambient.js

### DIFF
--- a/js/ambient/ambient.js
+++ b/js/ambient/ambient.js
@@ -102,7 +102,6 @@
             for (let i = 0; i < count; i++) {
                 particles.push(reset({}));
             }
-            // if (trace && window.console) console.log('[ambient] setup', {count: count, area: area, w: s.width, h: s.height, cw: cw, ch: ch});
         };
         s.resize = function () {
             s.setup();
@@ -138,12 +137,7 @@
             }
             ctx.restore();
         };
-        // if (trace && window.console) {
-        //   var m0 = (typeof metrics === 'function') ? metrics() : { width: s.width, height: s.height };
-        //   console.log('[ambient] created', { C: C, size: { w: m0.width, h: m0.height }, dpi: window.devicePixelRatio||1 });
-        //   window.__ambient = { config: C, instance: s };
-        // eslint-disable-next-line no-unused-vars
-    } catch (e) {
-        /* if (window.console) console.warn('[ambient] error', ignoredError); */
+    } catch {
+        // ignore
     }
 })();


### PR DESCRIPTION
This change improves the maintainability and readability of `js/ambient/ambient.js` by removing dead code in the form of comments. Specifically:
- Removed a commented-out debug log in the `s.setup` function.
- Removed a block of commented-out diagnostic code and instance recording at the end of the script.
- Cleaned up the `catch` block by removing a commented-out warning and switching to optional catch binding, which also allowed for the removal of an unused variable and its ESLint suppression.
These changes have no effect on the functionality of the code but result in a cleaner, more readable file.

---
*PR created automatically by Jules for task [7175957267212940821](https://jules.google.com/task/7175957267212940821) started by @ryusoh*