### PR TITLE
⚡ Bolt: Parallelize fetchPortfolioData requests

### DIFF
--- a/js/services/dataService.js
+++ b/js/services/dataService.js
@@ -50,8 +50,11 @@ async function fetchJSON(url) {
 }
 
 async function fetchPortfolioData() {
-    const holdingsDetails = await fetchJSON(HOLDINGS_DETAILS_URL);
-    const prices = await fetchJSON(FUND_DATA_URL);
+    // ⚡ Bolt: Fetch data concurrently for better performance instead of sequentially
+    const [holdingsDetails, prices] = await Promise.all([
+        fetchJSON(HOLDINGS_DETAILS_URL),
+        fetchJSON(FUND_DATA_URL),
+    ]);
     return { holdingsDetails, prices };
 }
 

--- a/tests/python/benchmark_calculate_stats.py
+++ b/tests/python/benchmark_calculate_stats.py
@@ -6,10 +6,10 @@ from pathlib import Path
 PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 sys.path.append(str(PROJECT_ROOT))
 
-import numpy as np
-import pandas as pd
+import numpy as np  # noqa: E402
+import pandas as pd  # noqa: E402
 
-from scripts.ratios.calculate_ratios import calculate_stats
+from scripts.ratios.calculate_ratios import calculate_stats  # noqa: E402
 
 # Mocking pd.read_parquet and other dependencies
 original_read_parquet = pd.read_parquet

--- a/tests/python/benchmark_ratios.py
+++ b/tests/python/benchmark_ratios.py
@@ -85,7 +85,9 @@ def method_zip(df):
     trade_values = df['trade_value'].to_numpy(dtype=float)
     order_types = df['order_type'].to_numpy()
 
-    for security, qty, trade_value, order_type in zip(securities, qtys, trade_values, order_types, strict=False):
+    for security, qty, trade_value, order_type in zip(
+        securities, qtys, trade_values, order_types, strict=False
+    ):
         price = trade_value / qty if qty else 0.0
         order_type_str = str(order_type).strip().lower()
         if qty <= 0 or price <= 0:
@@ -109,10 +111,9 @@ def method_zip(df):
     return realized_gain_total
 
 
-from collections import deque
-
-
 def method_zip_deque(df):
+    from collections import deque
+
     realized_gain_total = 0.0
     lots_by_security = {}
 
@@ -121,7 +122,9 @@ def method_zip_deque(df):
     trade_values = df['trade_value'].to_numpy(dtype=float)
     order_types = df['order_type'].to_numpy()
 
-    for security, qty, trade_value, order_type in zip(securities, qtys, trade_values, order_types, strict=False):
+    for security, qty, trade_value, order_type in zip(
+        securities, qtys, trade_values, order_types, strict=False
+    ):
         price = trade_value / qty if qty else 0.0
         order_type_str = str(order_type).strip().lower()
         if qty <= 0 or price <= 0:

--- a/tests/python/test_generate_pe_data.py
+++ b/tests/python/test_generate_pe_data.py
@@ -212,7 +212,6 @@ class TestGeneratePEData(unittest.TestCase):
         self.assertEqual(data["points"][0]["eps"], 9.99)
         self.assertEqual(data["points"][0]["date"], pd.Timestamp("2020-12-31"))
 
-
     @patch("scripts.generate_pe_data.urllib.request.urlopen")
     @patch.dict("os.environ", {"SCRAPER_API_KEY": "test_key"})
     def test_scrape_wsj_forward_pe_https(self, mock_urlopen) -> None:
@@ -237,6 +236,7 @@ class TestGeneratePEData(unittest.TestCase):
         self.assertTrue(req.full_url.startswith("https://api.scraperapi.com/"))
         self.assertIn("api_key=test_key", req.full_url)
         self.assertNotIn("http://api.scraperapi.com", req.full_url)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
💡 **What:** Modified `fetchPortfolioData()` in `js/services/dataService.js` to execute two independent JSON requests (`HOLDINGS_DETAILS_URL` and `FUND_DATA_URL`) concurrently using `Promise.all()`.
🎯 **Why:** To improve performance by eliminating sequential network requests. Previously, the code waited for the first request to complete before initiating the second.
📊 **Impact:** Reduces the total data fetching time from the sum of both requests to the duration of the slower request, resulting in faster initial data load.
🔬 **Measurement:** You can verify this by checking the network tab in your browser's developer tools. Both `holdings_details.json` and `fund_data.json` will now show as initiating at the same time rather than sequentially. Tests verify functionality is identical.

---
*PR created automatically by Jules for task [5458126095942808066](https://jules.google.com/task/5458126095942808066) started by @ryusoh*