### PR TITLE
🛡️ Sentinel: [High] Fix DOM XSS in Bayesian Probability Display

### DIFF
--- a/js/pages/analysis/lab.js
+++ b/js/pages/analysis/lab.js
@@ -581,16 +581,25 @@ function renderBayesOutput() {
         return;
     }
     const priors = state.bayesEngine.priors;
-    bayesOutput.innerHTML = priors
-        .map(
-            (p) => `
-        <div style="display: flex; justify-content: space-between; border-bottom: 1px dashed var(--ink); padding: 4px 0;">
-            <span>${p.name}</span>
-            <strong>${(p.prob * 100).toFixed(1)}%</strong>
-        </div>
-    `
-        )
-        .join('');
+    const elements = priors.map((p) => {
+        const row = document.createElement('div');
+        row.style.display = 'flex';
+        row.style.justifyContent = 'space-between';
+        row.style.borderBottom = '1px dashed var(--ink)';
+        row.style.padding = '4px 0';
+
+        const nameSpan = document.createElement('span');
+        nameSpan.textContent = p.name;
+
+        const probStrong = document.createElement('strong');
+        probStrong.textContent = `${(p.prob * 100).toFixed(1)}%`;
+
+        row.appendChild(nameSpan);
+        row.appendChild(probStrong);
+        return row;
+    });
+
+    bayesOutput.replaceChildren(...elements);
 }
 
 btnBayesBull.addEventListener('click', () => {
@@ -985,4 +994,6 @@ export const __analysisLabTesting = {
     computeScenarioOutcome,
     aggregateScenarios,
     extractScenarioTitles,
+    renderBayesOutput,
+    state,
 };

--- a/tests/js/pages/analysis/lab.test.js
+++ b/tests/js/pages/analysis/lab.test.js
@@ -119,4 +119,37 @@ describe('analysis lab data loading', () => {
             bear: 'Collapse',
         });
     });
+
+    describe('renderBayesOutput security', () => {
+        it('safely renders scenario names without executing HTML (DOM XSS prevention)', async () => {
+            global[FLAG] = true;
+            const module = await import('@pages/analysis/lab.js');
+            const { renderBayesOutput, state } = module.__analysisLabTesting;
+
+            // Mock bayesEngine with malicious data
+            state.bayesEngine = {
+                priors: [
+                    {
+                        name: '<img src=x onerror=alert(1)> Malicious Name',
+                        prob: 0.5,
+                    },
+                ],
+            };
+
+            const bayesOutput = document.getElementById('bayesOutput');
+            bayesOutput.innerHTML = ''; // Ensure clear
+
+            // Render
+            renderBayesOutput();
+
+            // Verify
+            // The HTML string representation of the output should escape or encode the tags,
+            // or the DOM should not contain actual <img> elements.
+            const imgElements = bayesOutput.querySelectorAll('img');
+            expect(imgElements.length).toBe(0);
+            expect(bayesOutput.textContent).toContain(
+                '<img src=x onerror=alert(1)> Malicious Name'
+            );
+        });
+    });
 });


### PR DESCRIPTION
🎯 **What:** The `renderBayesOutput` function in `js/pages/analysis/lab.js` had a DOM Cross-Site Scripting (XSS) vulnerability. It mapped scenario data directly into an HTML string and assigned it to `bayesOutput.innerHTML` without sanitization.

⚠️ **Risk:** If a malicious user or data source could control the `name` property of a Bayesian prior (e.g., `<img src=x onerror=alert(1)>`), it would execute arbitrary JavaScript in the context of the user's browser (DOM XSS).

🛡️ **Solution:** The unsafe template literal and `.innerHTML` assignment were replaced with safe DOM APIs. The function now iterates over the priors, creating `div`, `span`, and `strong` elements using `document.createElement()`, and assigns the user-controlled data using the safe `textContent` property. `replaceChildren()` is used to efficiently and securely replace the old elements. A unit test was also added to explicitly assert that this payload is no longer rendered as active HTML nodes.

---
*PR created automatically by Jules for task [16095913375694119728](https://jules.google.com/task/16095913375694119728) started by @ryusoh*