### PR TITLE
🎨 Palette: Improve keyboard focus visibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,9 @@
 **Learning:** Icon-only and symbol-only buttons, specifically currency toggles using `¥` for both CNY and JPY, cause visual ambiguity for sighted users and accessibility issues for screen readers. Navigation links containing only FontAwesome icons also lack context for assistive technologies. However, adding `title` attributes for hover labels compromises the app's minimalist design philosophy.
 
 **Action:** Always add `aria-label` attributes for screen readers when using icon-only or ambiguous symbol-based interactive elements, ensuring assistive tech can announce the elements correctly. To preserve UI minimalism, avoid using `title` attributes (hover labels) unless explicitly requested. Ensure decorative icons have `aria-hidden="true"`.
+
+## 2025-02-17 - Missing Focus Indicators for Keyboard Users
+
+**Learning:** The application explicitly stripped focus outlines (`outline: none;`) from interactive elements like currency toggles, calendar navigation buttons, and main navigation links without providing an alternative focus state. This creates a severe accessibility issue for keyboard users navigating via Tab.
+
+**Action:** Always provide a `:focus-visible` state when removing default `outline`. A 2px semi-transparent white outline with a small offset (`rgba(255, 255, 255, 0.5)`) works beautifully across dark UI elements without compromising the mouse/touch user experience.

--- a/css/calendar.css
+++ b/css/calendar.css
@@ -162,12 +162,17 @@ body.body-calendar {
     cursor: not-allowed;
 }
 
-/* Completely remove focus outline for all states */
+/* Completely remove focus outline for all states except explicit focus-visible */
 .cal-nav-btn:focus,
-.cal-nav-btn:focus-visible,
 .cal-nav-btn:focus-within {
     outline: none !important;
     box-shadow: none !important;
+}
+
+.cal-nav-btn:focus-visible {
+    outline: 2px solid rgba(255, 255, 255, 0.5) !important;
+    outline-offset: -2px !important;
+    border-radius: 4px;
 }
 
 /* Override Cal-Heatmap default styles for a dark theme */

--- a/css/container.css
+++ b/css/container.css
@@ -47,6 +47,13 @@
     outline: none;
 }
 
+.container a:focus-visible,
+.nav-container a:focus-visible {
+    outline: 2px solid rgba(255, 255, 255, 0.5);
+    outline-offset: -2px;
+    border-radius: 4px;
+}
+
 /* =========================================
    Desktop Styles (Min-Width: 769px)
    The Floating Vertical Glass Dock

--- a/css/toggle.css
+++ b/css/toggle.css
@@ -46,6 +46,12 @@
     outline: none;
 }
 
+.currency-toggle:focus-visible {
+    outline: 2px solid rgba(255, 255, 255, 0.5);
+    outline-offset: -2px;
+    border-radius: 4px;
+}
+
 .currency-toggle.active {
     background-color: rgba(0, 0, 0, 0.5); /* Slightly more transparent (was 0.6) */
     color: rgba(255, 255, 255, 0.85); /* 80% white active text */


### PR DESCRIPTION
**🎨 Palette: Improve keyboard focus visibility**

**💡 What:** 
Added a clear, subtle `:focus-visible` state (`outline: 2px solid rgba(255, 255, 255, 0.5)` with `outline-offset`) to key interactive elements like currency toggles, calendar navigation buttons, and main navigation links.

**🎯 Why:** 
Previously, these interactive elements had `outline: none` explicitly set, which removed the default browser focus ring without providing an alternative. This severely degraded the experience for keyboard users (navigating via 'Tab'), as they had no visual indicator of their current position on the page.

**📸 Before/After:** 
- *Before:* Tabbing through currency toggles and navigation showed no visual change.
- *After:* Tabbing clearly highlights the currently focused element with a white semi-transparent outline, without affecting the visually clean click experience for mouse/touch users (since it relies on `:focus-visible` instead of `:focus`).

**♿ Accessibility:** 
- Restores keyboard navigation visibility, adhering to WCAG 2.1 Success Criterion 2.4.7 (Focus Visible).
- Maintains design minimalism without compromising accessibility.

---
*PR created automatically by Jules for task [11242733422477063745](https://jules.google.com/task/11242733422477063745) started by @ryusoh*