### PR TITLE
🧪 [testing improvement description] Add tests for compute_cagr function

### DIFF
--- a/tests/python/test_calculate_ratios.py
+++ b/tests/python/test_calculate_ratios.py
@@ -57,6 +57,32 @@ class TestCalculateRatios(unittest.TestCase):
         self.assertEqual(format_percent(float("inf")), "N/A")
         self.assertEqual(format_percent(float("-inf")), "N/A")
 
+    def test_compute_cagr(self):
+        compute_cagr = self.cr.compute_cagr
+
+        # Happy paths
+        # 1 year doubling = 100%
+        self.assertAlmostEqual(compute_cagr([{"value": 100}, {"value": 200}], 1), 1.0)
+        # 2 year quadrupling = 100%
+        self.assertAlmostEqual(compute_cagr([{"value": 100}, {"value": 400}], 2), 1.0)
+        # fractional years
+        self.assertAlmostEqual(compute_cagr([{"value": 100}, {"value": 150}], 0.5), 1.25)
+
+        # Edge cases and error conditions
+        # empty series
+        self.assertIsNone(compute_cagr([], 1))
+        # series length < 2
+        self.assertIsNone(compute_cagr([{"value": 100}], 1))
+        # years <= 0
+        self.assertIsNone(compute_cagr([{"value": 100}, {"value": 200}], 0))
+        self.assertIsNone(compute_cagr([{"value": 100}, {"value": 200}], -1))
+        # start_val <= 0
+        self.assertIsNone(compute_cagr([{"value": 0}, {"value": 200}], 1))
+        self.assertIsNone(compute_cagr([{"value": -100}, {"value": 200}], 1))
+        # end_val <= 0
+        self.assertIsNone(compute_cagr([{"value": 100}, {"value": 0}], 1))
+        self.assertIsNone(compute_cagr([{"value": 100}, {"value": -200}], 1))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was an untested function `compute_cagr` in `scripts/ratios/calculate_ratios.py`. It is a pure mathematical function that calculates Compound Annual Growth Rate, making it critical for accurate financial reporting.

📊 **Coverage:** Scenarios covered include:
- Happy paths for integer years (doubling, quadrupling).
- Happy paths for fractional years.
- Error condition for empty series lists.
- Error condition for series lengths < 2.
- Edge cases for zero and negative years (`years <= 0`).
- Error conditions for non-positive start values and end values.

✨ **Result:** Test coverage for this financial calculation utility has been improved to ensure accurate behavior and handle edge cases gracefully without crashing. Tests run successfully via `unittest` and correctly catch any regressions to the mathematical formula or edge case checks.

---
*PR created automatically by Jules for task [15660709125016120723](https://jules.google.com/task/15660709125016120723) started by @ryusoh*