### PR TITLE
🧪 [testing improvement] Enhance `format_currency` tests for type handling and edge cases

### DIFF
--- a/tests/python/test_calculate_ratios.py
+++ b/tests/python/test_calculate_ratios.py
@@ -14,10 +14,16 @@ class TestCalculateRatios(unittest.TestCase):
     def setUpClass(cls):
         # Mock numpy and pandas before they are imported by calculate_ratios
         cls.mock_np = MagicMock()
+
         # Simple implementation of isfinite for the purpose of these tests
-        cls.mock_np.isfinite.side_effect = lambda x: isinstance(x, (int, float)) and not (
-            x != x or x == float("inf") or x == float("-inf")
-        )
+        def mock_isfinite(x):
+            if x is None or isinstance(x, str):
+                raise TypeError("ufunc 'isfinite' not supported for the input types")
+            return isinstance(x, (int, float)) and not (
+                x != x or x == float("inf") or x == float("-inf")
+            )
+
+        cls.mock_np.isfinite.side_effect = mock_isfinite
         cls.mock_np.nan = float("nan")
         cls.mock_np.inf = float("inf")
 
@@ -34,14 +40,25 @@ class TestCalculateRatios(unittest.TestCase):
         # Happy paths
         self.assertEqual(format_currency(1234.56), "$1,234.56")
         self.assertEqual(format_currency(1234.567), "$1,234.57")
+        self.assertEqual(format_currency(1234.564), "$1,234.56")
         self.assertEqual(format_currency(0), "$0.00")
         self.assertEqual(format_currency(-1234.56), "$-1,234.56")
         self.assertEqual(format_currency(1000000), "$1,000,000.00")
+
+        # Small values
+        self.assertEqual(format_currency(0.001), "$0.00")
+        self.assertEqual(format_currency(-0.001), "$-0.00")
 
         # Edge cases (non-finite)
         self.assertEqual(format_currency(float("nan")), "N/A")
         self.assertEqual(format_currency(float("inf")), "N/A")
         self.assertEqual(format_currency(float("-inf")), "N/A")
+
+        # Invalid types
+        with self.assertRaises(TypeError):
+            format_currency(None)
+        with self.assertRaises(TypeError):
+            format_currency("123")
 
     def test_format_percent(self):
         format_percent = self.cr.format_percent


### PR DESCRIPTION
🎯 **What:** The `format_currency` function in `scripts/ratios/calculate_ratios.py` had basic test coverage, but lacked robust validation for invalid types and edge-case small decimal values. Additionally, the test mock for `numpy.isfinite` did not accurately mirror real-world error throwing behavior when given non-numeric inputs like strings or `None`.

📊 **Coverage:** 
* Added test cases for invalid types (e.g. `None`, `"123"`) to ensure `format_currency` raises the correct `TypeError` as expected when interfacing with `np.isfinite`. 
* Added test cases for small value boundaries (e.g., `0.001`, `-0.001` resulting in `$0.00` and `$-0.00`).
* Added test cases for rounding behaviors on specific fractionals.
* Refactored `setUpClass` to implement a better `mock_isfinite` that mimics `numpy.isfinite` properly throwing `TypeError` rather than failing silently on string/None.

✨ **Result:** Improved test coverage and reliability for string manipulation and data formatting utility functions. The tests are more accurate against real `numpy` usage constraints, preventing bugs when handling dirty float values.

---
*PR created automatically by Jules for task [13098397634443392248](https://jules.google.com/task/13098397634443392248) started by @ryusoh*