### PR TITLE
🎨 Palette: Add accessibility attributes to analysis dashboard

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -11,3 +11,9 @@
 **Learning:** The application explicitly stripped focus outlines (`outline: none;`) from interactive elements like currency toggles, calendar navigation buttons, and main navigation links without providing an alternative focus state. This creates a severe accessibility issue for keyboard users navigating via Tab.
 
 **Action:** Always provide a `:focus-visible` state when removing default `outline`. A 2px semi-transparent white outline with a small offset (`rgba(255, 255, 255, 0.5)`) works beautifully across dark UI elements without compromising the mouse/touch user experience.
+
+## 2026-03-10 - Dynamic Async Results Need aria-live Updates
+
+**Learning:** When injecting dynamic output asynchronously via JavaScript (like Monte Carlo risk outputs or Bayesian text updates), the screen reader will remain completely silent because the new DOM nodes don't automatically trigger an announcement. Additionally, a `<canvas>` element without a `role="img"` and `aria-label` acts as a complete black box, making visual simulation feedback entirely inaccessible to non-sighted users.
+
+**Action:** Always add `aria-live="polite"` to parent containers that will be dynamically populated with important async results so that screen readers announce the changes naturally. Furthermore, give every meaningful `<canvas>` a semantic `role="img"` with a descriptive `aria-label`.

--- a/analysis/index.html
+++ b/analysis/index.html
@@ -38,12 +38,12 @@
                                 <div class="block-header">
                                     <h3>Scenario Outcomes</h3>
                                 </div>
-                                <div class="card-row" id="scenarioResults"></div>
+                                <div class="card-row" id="scenarioResults" aria-live="polite"></div>
                             </article>
 
                             <article class="value-card">
                                 <h3>Value Bands</h3>
-                                <dl id="valueBands"></dl>
+                                <dl id="valueBands" aria-live="polite"></dl>
                             </article>
                         </div>
 
@@ -63,6 +63,8 @@
                                         width="600"
                                         height="200"
                                         style="width: 100%; border: var(--border-thin)"
+                                        role="img"
+                                        aria-label="Monte Carlo Risk Simulation Chart"
                                     ></canvas>
                                     <div
                                         id="riskMetrics"
@@ -72,6 +74,7 @@
                                             gap: 15px;
                                             flex-wrap: wrap;
                                         "
+                                        aria-live="polite"
                                     >
                                         <!-- Metrics populated by JS -->
                                     </div>
@@ -108,6 +111,7 @@
                                 <div
                                     id="bayesOutput"
                                     style="font-family: var(--font-mono); color: var(--ink)"
+                                    aria-live="polite"
                                 ></div>
                             </article>
                         </div>


### PR DESCRIPTION
💡 What: Added `aria-live="polite"` to dynamically updated containers (`#scenarioResults`, `#valueBands`, `#riskMetrics`, `#bayesOutput`) and added `role="img"` with an `aria-label` to the Monte Carlo risk simulation `<canvas>`. Recorded this critical a11y learning in `.jules/palette.md`.
🎯 Why: Async content updates via JS were silently bypassing screen readers because standard `div` and `dl` tags do not automatically announce mutations. Additionally, the Monte Carlo canvas functioned as a black box without an accessible name, making its visual output inaccessible to non-sighted users.
📸 Before/After: Visual presentation is identical (good UX is invisible).
♿ Accessibility: Sighted screen-reader interactions will now successfully announce Bayesian signal outputs, Value Bands, and Scenario Outcomes, and will correctly identify the Monte Carlo visual chart.

---
*PR created automatically by Jules for task [10168727629862301031](https://jules.google.com/task/10168727629862301031) started by @ryusoh*