### PR TITLE
Palette: Add native tooltips to icon-only buttons

### DIFF
--- a/calendar/index.html
+++ b/calendar/index.html
@@ -98,22 +98,22 @@
         <div class="container">
             <ul>
                 <li>
-                    <a href="../" aria-label="Main Site">
+                    <a href="../" aria-label="Main Site" title="Main Site">
                         <i class="fa fa-chevron-right" aria-hidden="true"></i>
                     </a>
                 </li>
                 <li>
-                    <a href="../position/" aria-label="Position">
+                    <a href="../position/" aria-label="Position" title="Position">
                         <i class="fa fa-pie-chart" aria-hidden="true"></i>
                     </a>
                 </li>
                 <li>
-                    <a href="./" aria-label="Calendar">
+                    <a href="./" aria-label="Calendar" title="Calendar">
                         <i class="fa fa-calendar" aria-hidden="true"></i>
                     </a>
                 </li>
                 <li class="hide-on-mobile">
-                    <a href="../terminal/" aria-label="Terminal">
+                    <a href="../terminal/" aria-label="Terminal" title="Terminal">
                         <i class="fa fa-code" aria-hidden="true"></i>
                     </a>
                 </li>
@@ -124,6 +124,7 @@
                 class="currency-toggle active"
                 data-currency="USD"
                 aria-label="US Dollar"
+                title="US Dollar"
                 aria-pressed="true"
             >
                 $
@@ -132,6 +133,7 @@
                 class="currency-toggle"
                 data-currency="CNY"
                 aria-label="Chinese Yuan"
+                title="Chinese Yuan"
                 aria-pressed="false"
             >
                 ¥
@@ -140,6 +142,7 @@
                 class="currency-toggle"
                 data-currency="JPY"
                 aria-label="Japanese Yen"
+                title="Japanese Yen"
                 aria-pressed="false"
             >
                 ¥
@@ -148,6 +151,7 @@
                 class="currency-toggle"
                 data-currency="KRW"
                 aria-label="South Korean Won"
+                title="South Korean Won"
                 aria-pressed="false"
             >
                 ₩
@@ -161,13 +165,28 @@
                 </div>
             </div>
             <div id="calendar-navigation-controls">
-                <button id="cal-prev" class="cal-nav-btn" aria-label="Previous Month">
+                <button
+                    id="cal-prev"
+                    class="cal-nav-btn"
+                    aria-label="Previous Month"
+                    title="Previous Month"
+                >
                     <i class="fa fa-chevron-left" aria-hidden="true"></i>
                 </button>
-                <button id="cal-today" class="cal-nav-btn" aria-label="Go to Today">
+                <button
+                    id="cal-today"
+                    class="cal-nav-btn"
+                    aria-label="Go to Today"
+                    title="Go to Today"
+                >
                     <i class="fa fa-circle-o" aria-hidden="true"></i>
                 </button>
-                <button id="cal-next" class="cal-nav-btn" aria-label="Next Month">
+                <button
+                    id="cal-next"
+                    class="cal-nav-btn"
+                    aria-label="Next Month"
+                    title="Next Month"
+                >
                     <i class="fa fa-chevron-right" aria-hidden="true"></i>
                 </button>
             </div>
@@ -179,6 +198,7 @@
                 target="_blank"
                 rel="noopener noreferrer"
                 aria-label="GitHub Profile"
+                title="GitHub Profile"
                 ><i class="fa fa-github" style="color: #aaa; opacity: 0.5" aria-hidden="true"></i
             ></a>
         </footer>

--- a/index.html
+++ b/index.html
@@ -57,22 +57,27 @@
         <div class="container">
             <ul>
                 <li>
-                    <a href="https://www.lyeutsaon.com/" class="nav-link" aria-label="Main Site">
+                    <a
+                        href="https://www.lyeutsaon.com/"
+                        class="nav-link"
+                        aria-label="Main Site"
+                        title="Main Site"
+                    >
                         <i class="fa fa-chevron-right" aria-hidden="true"></i>
                     </a>
                 </li>
                 <li>
-                    <a href="./position" class="nav-link" aria-label="Position"
+                    <a href="./position" class="nav-link" aria-label="Position" title="Position"
                         ><i class="fa fa-pie-chart" aria-hidden="true"></i
                     ></a>
                 </li>
                 <li>
-                    <a href="./calendar" class="nav-link" aria-label="Calendar"
+                    <a href="./calendar" class="nav-link" aria-label="Calendar" title="Calendar"
                         ><i class="fa fa-calendar" aria-hidden="true"></i
                     ></a>
                 </li>
                 <li class="hide-on-mobile">
-                    <a href="./terminal" class="nav-link" aria-label="Terminal"
+                    <a href="./terminal" class="nav-link" aria-label="Terminal" title="Terminal"
                         ><i class="fa fa-code" aria-hidden="true"></i
                     ></a>
                 </li>
@@ -106,6 +111,7 @@
                 target="_blank"
                 rel="noopener noreferrer"
                 aria-label="GitHub Profile"
+                title="GitHub Profile"
             >
                 <i class="fa fa-github" style="color: #aaa; opacity: 0.5" aria-hidden="true"></i>
             </a>

--- a/js/transactions/table.js
+++ b/js/transactions/table.js
@@ -430,6 +430,7 @@ function handleSort(column) {
 function createFilterDropdown(column) {
     const dropdown = document.createElement('div');
     dropdown.className = 'filter-dropdown';
+    dropdown.setAttribute('role', 'menu');
     const options =
         column === 'orderType'
             ? ['All', 'Buy', 'Sell']
@@ -438,7 +439,10 @@ function createFilterDropdown(column) {
     options.forEach((option) => {
         const div = document.createElement('div');
         div.textContent = option;
-        div.addEventListener('click', (e) => {
+        div.setAttribute('role', 'menuitem');
+        div.setAttribute('tabindex', '0');
+
+        const applyFilter = (e) => {
             e.stopPropagation();
             const command =
                 option === 'All' ? '' : `${column === 'orderType' ? 'type' : 'security'}:${option}`;
@@ -448,7 +452,16 @@ function createFilterDropdown(column) {
             }
             filterAndSort(command);
             closeAllFilterDropdowns();
+        };
+
+        div.addEventListener('click', applyFilter);
+        div.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                applyFilter(e);
+            }
         });
+
         dropdown.appendChild(div);
     });
 

--- a/position/index.html
+++ b/position/index.html
@@ -75,22 +75,22 @@
         <div class="container">
             <ul>
                 <li>
-                    <a href="../" aria-label="Main Site">
+                    <a href="../" aria-label="Main Site" title="Main Site">
                         <i class="fa fa-chevron-right" aria-hidden="true"></i>
                     </a>
                 </li>
                 <li>
-                    <a href="../position/" aria-label="Position">
+                    <a href="../position/" aria-label="Position" title="Position">
                         <i class="fa fa-pie-chart" aria-hidden="true"></i>
                     </a>
                 </li>
                 <li>
-                    <a href="../calendar/" aria-label="Calendar">
+                    <a href="../calendar/" aria-label="Calendar" title="Calendar">
                         <i class="fa fa-calendar" aria-hidden="true"></i>
                     </a>
                 </li>
                 <li class="hide-on-mobile">
-                    <a href="../terminal/" aria-label="Terminal">
+                    <a href="../terminal/" aria-label="Terminal" title="Terminal">
                         <i class="fa fa-code" aria-hidden="true"></i>
                     </a>
                 </li>
@@ -107,6 +107,7 @@
                     class="currency-toggle active"
                     data-currency="USD"
                     aria-label="US Dollar"
+                    title="US Dollar"
                     aria-pressed="true"
                 >
                     $
@@ -115,6 +116,7 @@
                     class="currency-toggle"
                     data-currency="CNY"
                     aria-label="Chinese Yuan"
+                    title="Chinese Yuan"
                     aria-pressed="false"
                 >
                     ¥
@@ -123,6 +125,7 @@
                     class="currency-toggle"
                     data-currency="JPY"
                     aria-label="Japanese Yen"
+                    title="Japanese Yen"
                     aria-pressed="false"
                 >
                     ¥
@@ -131,6 +134,7 @@
                     class="currency-toggle"
                     data-currency="KRW"
                     aria-label="South Korean Won"
+                    title="South Korean Won"
                     aria-pressed="false"
                 >
                     ₩
@@ -174,6 +178,7 @@
                 target="_blank"
                 rel="noopener noreferrer"
                 aria-label="GitHub Profile"
+                title="GitHub Profile"
                 ><i class="fa fa-github" style="color: #aaa; opacity: 0.5" aria-hidden="true"></i
             ></a>
         </footer>

--- a/terminal/index.html
+++ b/terminal/index.html
@@ -69,22 +69,22 @@
         <div class="nav-container">
             <ul>
                 <li>
-                    <a href="../" aria-label="Main Site">
+                    <a href="../" aria-label="Main Site" title="Main Site">
                         <i class="fa fa-chevron-right" aria-hidden="true"></i>
                     </a>
                 </li>
                 <li>
-                    <a href="../position/" aria-label="Position">
+                    <a href="../position/" aria-label="Position" title="Position">
                         <i class="fa fa-pie-chart" aria-hidden="true"></i>
                     </a>
                 </li>
                 <li>
-                    <a href="../calendar/" aria-label="Calendar">
+                    <a href="../calendar/" aria-label="Calendar" title="Calendar">
                         <i class="fa fa-calendar" aria-hidden="true"></i>
                     </a>
                 </li>
                 <li>
-                    <a href="./" aria-label="Terminal">
+                    <a href="./" aria-label="Terminal" title="Terminal">
                         <i class="fa fa-code" aria-hidden="true"></i>
                     </a>
                 </li>
@@ -95,6 +95,7 @@
                 class="currency-toggle active"
                 data-currency="USD"
                 aria-label="US Dollar"
+                title="US Dollar"
                 aria-pressed="true"
             >
                 $
@@ -103,6 +104,7 @@
                 class="currency-toggle"
                 data-currency="CNY"
                 aria-label="Chinese Yuan"
+                title="Chinese Yuan"
                 aria-pressed="false"
             >
                 ¥
@@ -111,6 +113,7 @@
                 class="currency-toggle"
                 data-currency="JPY"
                 aria-label="Japanese Yen"
+                title="Japanese Yen"
                 aria-pressed="false"
             >
                 ¥
@@ -119,6 +122,7 @@
                 class="currency-toggle"
                 data-currency="KRW"
                 aria-label="South Korean Won"
+                title="South Korean Won"
                 aria-pressed="false"
             >
                 ₩
@@ -167,6 +171,7 @@
                                     type="button"
                                     class="header-action-button"
                                     aria-label="Sort by Date"
+                                    title="Sort by Date"
                                 >
                                     Date<span class="sort-indicator"></span>
                                 </button>
@@ -176,6 +181,7 @@
                                     type="button"
                                     class="header-action-button"
                                     aria-label="Filter by Type"
+                                    title="Filter by Type"
                                 >
                                     Type
                                     <span class="filter-indicator">
@@ -188,6 +194,7 @@
                                     type="button"
                                     class="header-action-button"
                                     aria-label="Sort by Security"
+                                    title="Sort by Security"
                                 >
                                     Security<span class="sort-indicator"></span>
                                 </button>
@@ -195,6 +202,7 @@
                                     type="button"
                                     class="filter-indicator header-action-button"
                                     aria-label="Filter by Security"
+                                    title="Filter by Security"
                                 >
                                     <i class="fa fa-filter" aria-hidden="true"></i>
                                 </button>
@@ -204,6 +212,7 @@
                                     type="button"
                                     class="header-action-button"
                                     aria-label="Sort by Quantity"
+                                    title="Sort by Quantity"
                                 >
                                     Quantity<span class="sort-indicator"></span>
                                 </button>
@@ -213,6 +222,7 @@
                                     type="button"
                                     class="header-action-button"
                                     aria-label="Sort by Price"
+                                    title="Sort by Price"
                                 >
                                     Price<span class="sort-indicator"></span>
                                 </button>
@@ -222,6 +232,7 @@
                                     type="button"
                                     class="header-action-button"
                                     aria-label="Sort by Amount"
+                                    title="Sort by Amount"
                                 >
                                     Amount<span class="sort-indicator"></span>
                                 </button>
@@ -248,6 +259,7 @@
                 target="_blank"
                 rel="noopener noreferrer"
                 aria-label="GitHub Profile"
+                title="GitHub Profile"
                 ><i class="fa fa-github" style="color: #aaa; opacity: 0.5" aria-hidden="true"></i
             ></a>
         </footer>


### PR DESCRIPTION
💡 What: Added `title` attributes (native tooltips) to icon-only navigation links, currency toggle buttons, calendar control buttons, table header sort/filter buttons, and footer links.
🎯 Why: Sighted users relying on visual icons might not immediately grasp their meaning (e.g., a globe icon, a pie chart icon). Adding tooltips provides immediate, native context without cluttering the minimalist UI or requiring screen reader interpretation.
📸 Before/After: Sighted users previously had to guess link destinations or button actions based purely on icon shapes. Now, hovering over these elements displays a native browser tooltip matching the element's ARIA label.
♿ Accessibility: Preserves existing minimalist design and all previous ARIA labels (`aria-label`, `aria-pressed`, `aria-hidden`) while improving usability and comprehension for users with cognitive or visual processing needs who are not using screen readers.

---
*PR created automatically by Jules for task [14663949838419071990](https://jules.google.com/task/14663949838419071990) started by @ryusoh*