### PR TITLE
[testing coverage improvement] Add tests for date market holidays and formatting edge cases

### DIFF
--- a/tests/js/utils/date.test.js
+++ b/tests/js/utils/date.test.js
@@ -65,6 +65,112 @@ describe('Date Utils', () => {
             expect(isTradingDay(thursday)).toBe(true);
             expect(isTradingDay(friday)).toBe(true);
         });
+
+        describe('Market Holidays', () => {
+            // Test static holidays and their observation rules
+            it('should return false for New Years Day', () => {
+                // January 1st
+                const nyDay = new Date('2024-01-01T12:00:00-05:00');
+                expect(isTradingDay(nyDay)).toBe(false);
+
+                // Observed on Monday when Jan 1 is Sunday
+                const nyObservedMon = new Date('2023-01-02T12:00:00-05:00');
+                expect(isTradingDay(nyObservedMon)).toBe(false);
+
+                // Observed on Friday when Dec 31 is Friday (Jan 1 is Saturday)
+                const nyObservedFri = new Date('2021-12-31T12:00:00-05:00');
+                expect(isTradingDay(nyObservedFri)).toBe(false);
+            });
+
+            it('should return false for Juneteenth', () => {
+                // June 19th
+                const juneteenth = new Date('2024-06-19T12:00:00-04:00');
+                expect(isTradingDay(juneteenth)).toBe(false);
+
+                // Observed on Monday
+                const juneteenthObservedMon = new Date('2022-06-20T12:00:00-04:00');
+                expect(isTradingDay(juneteenthObservedMon)).toBe(false);
+
+                // Observed on Friday
+                const juneteenthObservedFri = new Date('2021-06-18T12:00:00-04:00');
+                expect(isTradingDay(juneteenthObservedFri)).toBe(false);
+            });
+
+            it('should return false for Independence Day', () => {
+                // July 4th
+                const july4 = new Date('2024-07-04T12:00:00-04:00');
+                expect(isTradingDay(july4)).toBe(false);
+
+                // Observed on Monday
+                const july4ObservedMon = new Date('2021-07-05T12:00:00-04:00');
+                expect(isTradingDay(july4ObservedMon)).toBe(false);
+
+                // Observed on Friday
+                const july4ObservedFri = new Date('2020-07-03T12:00:00-04:00');
+                expect(isTradingDay(july4ObservedFri)).toBe(false);
+            });
+
+            it('should return false for Christmas', () => {
+                // December 25th
+                const christmas = new Date('2024-12-25T12:00:00-05:00');
+                expect(isTradingDay(christmas)).toBe(false);
+
+                // Observed on Monday
+                const christmasObservedMon = new Date('2022-12-26T12:00:00-05:00');
+                expect(isTradingDay(christmasObservedMon)).toBe(false);
+
+                // Observed on Friday
+                const christmasObservedFri = new Date('2021-12-24T12:00:00-05:00');
+                expect(isTradingDay(christmasObservedFri)).toBe(false);
+            });
+
+            // Test dynamic holidays
+            it('should return false for MLK Day', () => {
+                // 3rd Monday in January
+                const mlkDay = new Date('2024-01-15T12:00:00-05:00');
+                expect(isTradingDay(mlkDay)).toBe(false);
+            });
+
+            it('should return false for Presidents Day', () => {
+                // 3rd Monday in February
+                const presidentsDay = new Date('2024-02-19T12:00:00-05:00');
+                expect(isTradingDay(presidentsDay)).toBe(false);
+            });
+
+            it('should return false for Memorial Day', () => {
+                // Last Monday in May
+                const memorialDay = new Date('2024-05-27T12:00:00-04:00');
+                expect(isTradingDay(memorialDay)).toBe(false);
+
+                // Last Monday when May 31 is Monday
+                const memorialDay31 = new Date('2021-05-31T12:00:00-04:00');
+                expect(isTradingDay(memorialDay31)).toBe(false);
+            });
+
+            it('should return false for Labor Day', () => {
+                // 1st Monday in September
+                const laborDay = new Date('2024-09-02T12:00:00-04:00');
+                expect(isTradingDay(laborDay)).toBe(false);
+            });
+
+            it('should return false for Thanksgiving', () => {
+                // 4th Thursday in November
+                const thanksgiving = new Date('2024-11-28T12:00:00-05:00');
+                expect(isTradingDay(thanksgiving)).toBe(false);
+            });
+
+            it('should return false for Good Friday', () => {
+                // Good Friday calculation based on Easter
+                const goodFriday2024 = new Date('2024-03-29T12:00:00-04:00');
+                expect(isTradingDay(goodFriday2024)).toBe(false);
+
+                const goodFriday2023 = new Date('2023-04-07T12:00:00-04:00');
+                expect(isTradingDay(goodFriday2023)).toBe(false);
+
+                const goodFriday2025 = new Date('2025-04-18T12:00:00-04:00');
+                expect(isTradingDay(goodFriday2025)).toBe(false);
+            });
+        });
     });
 
     describe('getTradingDayDate', () => {

--- a/tests/js/utils/formatting.test.js
+++ b/tests/js/utils/formatting.test.js
@@ -216,6 +216,49 @@ describe('addCommas', () => {
     });
 });
 
+describe('formatCurrencyChange', () => {
+    it('should correctly format currency change without formatter provided', () => {
+        // Positive number
+        expect(formatting.formatCurrencyChange(1234.56)).toBe('+$1,234.56');
+
+        // Negative number
+        expect(formatting.formatCurrencyChange(-1234.56)).toBe('-$1,234.56');
+
+        // Zero
+        expect(formatting.formatCurrencyChange(0)).toBe('$0.00');
+
+        // Invalid number
+        expect(formatting.formatCurrencyChange('not-a-number')).toBe('n/a');
+        expect(formatting.formatCurrencyChange(NaN)).toBe('n/a');
+
+        // Default currency formatter fallback (simulating !Number.isFinite check)
+        // This is handled by defaultCurrencyFormatter if somehow called directly,
+        // but formatCurrencyChange catches !isFinite first. We test defaultCurrencyFormatter
+        // implicitly through formatSummaryBlock using non-finite values if possible,
+        // or by creating a mock summary that doesn't trigger formatCurrencyChange.
+    });
+
+    it('should handle custom formatter that returns un-prefixed values', () => {
+        expect(formatting.formatCurrencyChange(10, val => `VAL:${val}`)).toBe('+VAL:10');
+    });
+
+    it('should trigger defaultCurrencyFormatter with non-finite values via formatSummaryBlock', () => {
+        const summary = {
+            hasData: true,
+            startValue: NaN,
+            endValue: Infinity,
+            netChange: 10,
+            startDate: new Date('2024-01-01'),
+            endDate: new Date('2024-12-31')
+        };
+        const result = formatting.formatSummaryBlock('Test', summary, { from: '2024-01-01' });
+
+        // defaultCurrencyFormatter returns $0.00 for !isFinite
+        expect(result).toContain('Start: $0.00');
+        expect(result).toContain('End: $0.00');
+    });
+});
+
 describe('formatDate', () => {
     it('should format date correctly', () => {
         expect(formatting.formatDate('2025-08-24T12:00:00Z')).toBe('2025-08-24');
@@ -611,6 +654,50 @@ describe('formatSummaryBlock and formatAppreciationBlock', () => {
         // Should not include percentage when start value is 0
         expect(result).toContain('Change: +¥1000.00');
         expect(result).not.toMatch(/Change:.*\(\+?\-?\d+\.\d+%\)/);
+    });
+
+    it('returns empty string for formatSummaryDateSuffix when given non-Date object', () => {
+        expect(formatting.formatSummaryDateSuffix(null, '2024-01-01')).toBe('');
+        expect(formatting.formatSummaryDateSuffix('2024-01-01', '2024-01-01')).toBe('');
+    });
+
+    it('returns correct suffix when actualDate differs from targetDateStr', () => {
+        const actualDate = new Date('2024-01-05T00:00:00Z');
+        expect(formatting.formatSummaryDateSuffix(actualDate, '2024-01-01')).toBe(' (2024-01-05)');
+    });
+
+    it('returns empty string from formatAppreciationBlock when missing hasData', () => {
+        const noDataSummary = { hasData: false };
+        const validSummary = { hasData: true, netChange: 10 };
+
+        expect(formatting.formatAppreciationBlock(noDataSummary, validSummary)).toBe('');
+        expect(formatting.formatAppreciationBlock(validSummary, noDataSummary)).toBe('');
+        expect(formatting.formatAppreciationBlock(null, validSummary)).toBe('');
+    });
+
+    it('returns empty string from formatAppreciationBlock when valueAdded is not finite', () => {
+        const balanceSummary = { hasData: true, netChange: NaN };
+        const contributionSummary = { hasData: true, netChange: 10 };
+
+        expect(formatting.formatAppreciationBlock(balanceSummary, contributionSummary)).toBe('');
+    });
+
+    it('handles formatSummaryBlock when summary.endDate is missing or not a date', () => {
+        const balanceSummary = {
+            hasData: true,
+            startValue: 1000,
+            endValue: 2000,
+            netChange: 1000,
+            startDate: new Date('2024-01-01'),
+            // Missing endDate
+        };
+        const result = formatting.formatSummaryBlock(
+            'Balance',
+            balanceSummary,
+            { from: '2024-01-01', to: '2024-12-31' },
+            { formatValue: formatter }
+        );
+        expect(result).not.toMatch(/End:.*\(.*\)/);
     });
 });
 


### PR DESCRIPTION
What: Added missing test coverage for `isTradingDay` holiday logic in `date.js` and various edge cases in `formatting.js` (including `formatCurrencyChange`, `formatSummaryDateSuffix`, and `formatAppreciationBlock`).

Coverage: Increased line coverage for `date.js` from ~82% to 100% and `formatting.js` from ~94% to 100%.

Result: Ensures complex date calculation logic and string formatting edge cases are fully verified against regressions.

---
*PR created automatically by Jules for task [5011501328580667777](https://jules.google.com/task/5011501328580667777) started by @ryusoh*