### PR TITLE
Palette: Add matching border-radius to table focus ring

### DIFF
--- a/css/terminal/table.css
+++ b/css/terminal/table.css
@@ -221,3 +221,9 @@ th.sortable[data-sort='desc'] .sort-indicator::after {
 .filter-dropdown div:hover {
     background-color: var(--hover-bg);
 }
+
+.table-responsive-container:focus-visible {
+    outline: 2px solid rgba(255, 255, 255, 0.5);
+    outline-offset: -2px;
+    border-radius: 16px;
+}

--- a/tests/js/pages/analysis/bayes.test.js
+++ b/tests/js/pages/analysis/bayes.test.js
@@ -1,4 +1,3 @@
-
 import { BayesianEngine } from '../../../../js/pages/analysis/bayes.js';
 
 describe('BayesianEngine', () => {


### PR DESCRIPTION
💡 What: The UX enhancement added: `border-radius: 16px;` to `.table-responsive-container:focus-visible` in `css/terminal/table.css`.
🎯 Why: The user problem it solves: During keyboard navigation, `.table-responsive-container` uses a default inherited 8px border-radius, or squared focus, which looks harsh and misaligned with the terminal's actual 16px border-radius.
📸 Before/After: Visual change in the focus ring when tabbing to the table in `/terminal`.
♿ Accessibility: Improves visual accessibility and polish for keyboard users without affecting mouse/touch users.

---
*PR created automatically by Jules for task [4676832573837670969](https://jules.google.com/task/4676832573837670969) started by @ryusoh*