### PR TITLE
Palette: Add helpful placeholder text to terminal input

### DIFF
--- a/terminal/index.html
+++ b/terminal/index.html
@@ -143,6 +143,7 @@
                         autocomplete="off"
                         autofocus
                         aria-label="Terminal input"
+                        placeholder="Try 'help' or 'ls'..."
                     />
                 </div>
             </div>


### PR DESCRIPTION
Palette: Add helpful placeholder text to terminal input

* 💡 What: Added `placeholder="Try 'help' or 'ls'..."` to the terminal input field.
* 🎯 Why: Solves the "Missing empty states with helpful guidance" issue by providing immediate, intuitive instructions to users who might not know what commands are available in the terminal.
* ♿ Accessibility: Improves usability by giving immediate context to screen readers and keyboard users when the input is focused empty.

---
*PR created automatically by Jules for task [7473769948149162798](https://jules.google.com/task/7473769948149162798) started by @ryusoh*