### PR TITLE
Palette: [UX polish] Smooth focus ring border radius for terminal table headers

### DIFF
--- a/css/terminal/table.css
+++ b/css/terminal/table.css
@@ -142,6 +142,7 @@ th.filterable {
 .header-action-button:focus-visible {
     outline: 2px solid rgba(255, 255, 255, 0.5);
     outline-offset: 4px;
+    border-radius: 4px;
 }
 
 /* Ensure padding matches what TH had when it was clickable */


### PR DESCRIPTION
💡 **What:** Added a matching `border-radius: 4px;` to the `:focus-visible` pseudo-class for `.header-action-button` in the terminal table headers.
🎯 **Why:** Previously, focusing on interactive table headers (like the date, description, or amount columns in the terminal) using the Tab key resulted in a sharp, squared outline. This visually conflicted with the inherently rounded shape (4px border-radius) of the underlying button container, breaking the UI's cohesive look and feel during keyboard navigation.
📸 **Before/After:** Before, the focus ring was a strict rectangle with right angles. After, the focus ring smoothly traces the rounded 4px corners of the header buttons.
♿ **Accessibility:** This directly benefits keyboard-only users by providing a polished, aesthetically pleasing, and native-feeling focus state that adheres to the established design system without sacrificing the visibility of the outline.

*(Includes cleanup of extraneous log files before submission to maintain pristine repository state).*

---
*PR created automatically by Jules for task [7499456363717718137](https://jules.google.com/task/7499456363717718137) started by @ryusoh*