### PR TITLE
🎨 Palette: Add focus-visible to footer link

### DIFF
--- a/css/layout.css
+++ b/css/layout.css
@@ -163,3 +163,9 @@ a.nav-back {
         display: none; /* Hidden by default on mobile; toggled via JS */
     }
 }
+
+footer a:focus-visible {
+    outline: 2px solid rgba(255, 255, 255, 0.5);
+    outline-offset: -2px;
+    border-radius: 4px;
+}


### PR DESCRIPTION
Added a `:focus-visible` state to the GitHub link in the footer to improve keyboard accessibility. This change ensures consistent visual feedback when navigating via Tab, matching the established focus ring pattern in the app.

---
*PR created automatically by Jules for task [16478693612384189965](https://jules.google.com/task/16478693612384189965) started by @ryusoh*