### PR TITLE
Bolt: Optimize chained slice and reduce in Monte Carlo simulation

### DIFF
--- a/js/pages/analysis/monte_carlo.worker.js
+++ b/js/pages/analysis/monte_carlo.worker.js
@@ -58,11 +58,20 @@ function runSimulation(config) {
     terminalValues.sort((a, b) => a - b);
 
     // Compute Metrics
-    const mean = terminalValues.reduce((a, b) => a + b, 0) / paths;
-    const VaR_95 = terminalValues[Math.floor(paths * 0.05)];
-    const CVaR_95 =
-        terminalValues.slice(0, Math.floor(paths * 0.05)).reduce((a, b) => a + b, 0) /
-        Math.floor(paths * 0.05);
+    // Bolt: Optimize chained slice and reduce with a single inline for loop
+    const cvarIndex = Math.floor(paths * 0.05);
+    let sum = 0;
+    let cvarSum = 0;
+    for (let i = 0; i < paths; i++) {
+        const val = terminalValues[i];
+        sum += val;
+        if (i < cvarIndex) {
+            cvarSum += val;
+        }
+    }
+    const mean = sum / paths;
+    const VaR_95 = terminalValues[cvarIndex];
+    const CVaR_95 = cvarSum / cvarIndex;
 
     // Create Histogram Data
     const histogram = createHistogram(terminalValues, 50);


### PR DESCRIPTION
💡 What: Replaced chained `.slice().reduce()` methods with a single O(N) `for` loop in `js/pages/analysis/monte_carlo.worker.js`.
🎯 Why: Using array allocation methods (`.slice()`) and chained higher-order functions (`.reduce()`) inside the simulation's metric calculation creates severe garbage collection (GC) pressure, especially when the path count is large. The intermediate arrays allocate unnecessary memory and the functional callbacks add overhead on the hot path. 
📊 Impact: Reduced O(N) memory allocation to O(1) space and consolidated two separate array reduction passes into a single iteration, resulting in faster and more memory-efficient risk metric computation.
🔬 Measurement: Verify tests run via `pnpm test` and `npm run verify:all` pass correctly. Ensure no regressions in calculating `CVaR_95`.

---
*PR created automatically by Jules for task [13989729152845049549](https://jules.google.com/task/13989729152845049549) started by @ryusoh*