### PR TITLE
Palette: Add keyboard focus indicator to footer links

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -46,3 +46,9 @@
 **Learning:** Text containers with `overflow-y: auto` (like the terminal output window) must be explicitly focusable so keyboard-only users can scroll through the content history. Without `tabindex="0"`, arrow keys will scroll the whole page instead of the specific container, making long logs inaccessible.
 
 **Action:** Always add `tabindex="0"` and an appropriate `:focus-visible` styling (e.g., `outline: 2px solid rgba(255, 255, 255, 0.5)`) to internally scrollable text areas or log outputs to enable keyboard scrolling.
+
+## 2026-04-11 - Footer Navigation Focus Accessibility
+
+**Learning:** The application explicitly stripped custom cursor attributes (`cursor: none !important;`) from footer links (`footer a`) to override default pointer styling, but simultaneously forgot to provide keyboard focus states (`:focus-visible`). This makes the GitHub profile link in the footer inaccessible for keyboard-only users who cannot perceive their tab position.
+
+**Action:** Always complement navigational footer links with explicit `:focus-visible` styling (`outline: 2px solid rgba(255, 255, 255, 0.5); outline-offset: 4px;`) whenever interfering with default browser interactive styling, ensuring the links remain identifiable for keyboard navigation.

--- a/css/base.css
+++ b/css/base.css
@@ -104,3 +104,9 @@ body.icon-font-ready .fa {
 .hidden {
     display: none;
 }
+
+footer a:focus-visible {
+    outline: 2px solid rgba(255, 255, 255, 0.5);
+    outline-offset: 4px;
+    border-radius: 4px;
+}

--- a/css/terminal/base.css
+++ b/css/terminal/base.css
@@ -222,3 +222,9 @@ footer {
     outline-offset: -2px;
     border-radius: 16px;
 }
+
+footer a:focus-visible {
+    outline: 2px solid rgba(255, 255, 255, 0.5);
+    outline-offset: 4px;
+    border-radius: 4px;
+}


### PR DESCRIPTION
**What:** Added `:focus-visible` outline styles to the GitHub link within the application footers.
**Why:** The `<footer> a` tag had default browser outlines suppressed and lacked explicit focus indicators, making it completely invisible to keyboard-only users navigating via the Tab key.
**Before/After:** No visual change for mouse users. Keyboard users now see a 2px white semi-transparent ring when tabbing onto the footer link. 
**Accessibility:** Ensures WCAG compliance for focus visibility, allowing screen reader and keyboard-only users to discern their current position within the footer navigation.

---
*PR created automatically by Jules for task [10611003968119835251](https://jules.google.com/task/10611003968119835251) started by @ryusoh*