### PR TITLE
fix: add geography and marketcap generators to TWRR pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,8 @@ TWRR_STEPS := scripts/twrr/step01_load_transactions.py \
 		 scripts/twrr/step04_compute_holdings.py \
 	 scripts/data/fetch_ticker_metadata.py \
 	 scripts/generate_composition_data.py \
+	 scripts/generate_geography_data.py \
+	 scripts/generate_marketcap_from_composition.py \
 	 scripts/generate_pe_data.py \
 	 scripts/generate_yield_data.py \
 	 scripts/twrr/step05_cashflows.py \

--- a/tests/python/test_ci_parity.py
+++ b/tests/python/test_ci_parity.py
@@ -109,6 +109,27 @@ class TestCIParity:
             "wrangler" in dev_deps
         ), "wrangler should be in devDependencies for deploy-worker target"
 
+    def test_twrr_steps_include_all_figure_generators(self):
+        """Verify TWRR_STEPS includes all figure data generators.
+
+        Regression: geography and marketcap plots were stale because their
+        generation scripts were only in the weekly VT workflow, not in the
+        main TWRR pipeline.  All generate_*_data.py / generate_*_from_*.py
+        scripts that produce figures must run on every twrr-refresh.
+        """
+        content = get_makefile_content()
+
+        required_scripts = [
+            "scripts/generate_composition_data.py",
+            "scripts/generate_geography_data.py",
+            "scripts/generate_marketcap_from_composition.py",
+        ]
+        for script in required_scripts:
+            assert script in content, (
+                f"TWRR_STEPS missing {script} — "
+                "figure data will be stale between weekly VT updates"
+            )
+
     def test_makefile_uses_npx_yes_for_wrangler(self):
         """Verify Makefile uses npx --yes for wrangler."""
         content = get_makefile_content()


### PR DESCRIPTION
## Summary
- Geography and marketcap plot data was stale because their generation scripts only ran in the weekly VT update workflow, not on every `make twrr-refresh`
- Added `generate_geography_data.py` and `generate_marketcap_from_composition.py` to `TWRR_STEPS` in the Makefile
- Added regression test in `test_ci_parity.py` to ensure all figure generators stay in the pipeline

## Test plan
- [x] New test `test_twrr_steps_include_all_figure_generators` passes
- [ ] Run `make twrr-refresh` and verify geography/marketcap plots show the latest date

🤖 Generated with [Claude Code](https://claude.com/claude-code)