### PR TITLE
🔒 [security fix] Mitigate DOM XSS in calendar labels

### DIFF
--- a/js/pages/calendar/index.js
+++ b/js/pages/calendar/index.js
@@ -311,12 +311,12 @@ export function renderLabels(cal, byDate, state, currencySymbols) {
                     .ease(d3.easeCubicInOut)
                     .style('opacity', 0)
                     .on('end', function () {
-                        d3.select(this).html('');
+                        d3.select(this).text('');
                         state.isAnimating = false;
                     });
             } else {
                 // Fallback for test environment
-                fadeOutSelection.html('');
+                fadeOutSelection.text('');
                 state.isAnimating = false;
             }
         } else {
@@ -324,7 +324,7 @@ export function renderLabels(cal, byDate, state, currencySymbols) {
             const textNodes = d3
                 .select(CALENDAR_SELECTORS.heatmap)
                 .selectAll('text.ch-subdomain-text');
-            textNodes.html('');
+            textNodes.text('');
         }
         return;
     }


### PR DESCRIPTION
🎯 **What:** Potential DOM XSS vulnerability in the calendar page.
⚠️ **Risk:** Using `.html('')` on a D3 selection, even with an empty string, can be flagged as an insecure sink in security audits. If the selection or the input were ever to be influenced by untrusted data, it could lead to Cross-Site Scripting (XSS).
🛡️ **Solution:** Replaced three instances of `.html('')` with `.text('')` in `js/pages/calendar/index.js`. This is functionally equivalent for clearing elements but uses a safe sink that bypasses the HTML parser. Verified via linting and visual inspection of calendar transitions.

---
*PR created automatically by Jules for task [11991614429417996607](https://jules.google.com/task/11991614429417996607) started by @ryusoh*