### PR TITLE
🎨 Palette: Add keyboard focus indicator to terminal input

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -52,3 +52,9 @@
 **Learning:** The application explicitly stripped custom cursor attributes (`cursor: none !important;`) from footer links (`footer a`) to override default pointer styling, but simultaneously forgot to provide keyboard focus states (`:focus-visible`). This makes the GitHub profile link in the footer inaccessible for keyboard-only users who cannot perceive their tab position.
 
 **Action:** Always complement navigational footer links with explicit `:focus-visible` styling (`outline: 2px solid rgba(255, 255, 255, 0.5); outline-offset: 4px;`) whenever interfering with default browser interactive styling, ensuring the links remain identifiable for keyboard navigation.
+
+## 2026-04-13 - Terminal Input Focus Accessibility
+
+**Learning:** Text inputs that rely on placeholder or minimalist styling (like `.terminal-input` acting as a custom command line) often explicitly strip default outlines (`outline: none;`) to look sleek. Without a `:focus-visible` state, keyboard users cannot visually confirm that the input field is active and ready to receive commands.
+
+**Action:** Always complement text inputs that use `outline: none;` with explicit `:focus-visible` styling (`outline: 2px solid rgba(255, 255, 255, 0.5); outline-offset: -2px;`) to ensure the interactive input field remains identifiable for keyboard navigation.

--- a/css/terminal/terminal.css
+++ b/css/terminal/terminal.css
@@ -72,6 +72,12 @@
     overflow: hidden;
 }
 
+.terminal-input:focus-visible {
+    outline: 2px solid rgba(255, 255, 255, 0.5);
+    outline-offset: -2px;
+    border-radius: 4px;
+}
+
 .terminal-crosshair-overlay {
     position: absolute;
     inset: 0;


### PR DESCRIPTION
💡 What: Added `:focus-visible` styles to the `.terminal-input` element in `css/terminal/terminal.css` to explicitly render a 2px semi-transparent outline when focused via keyboard.

🎯 Why: The original CSS stripped the default focus outline (`outline: none;`) without providing an accessible alternative. Keyboard-only users were unable to visually confirm when they had successfully tabbed into or focused the terminal input field.

📸 Before/After: Verified via Playwright screenshots (not directly available in the PR body but tested locally in verification).

♿ Accessibility: Ensures that keyboard users receive a clear, high-contrast, visually pleasing indication of active focus on the primary interactive text field in the terminal view. This resolves a significant WCAG focus visibility violation.

---
*PR created automatically by Jules for task [14314824591976212308](https://jules.google.com/task/14314824591976212308) started by @ryusoh*