### PR TITLE
Sentinel: Add Security Headers to Cloudflare Pages

### DIFF
--- a/_headers
+++ b/_headers
@@ -2,3 +2,5 @@
   X-Content-Type-Options: nosniff
   X-Frame-Options: DENY
   Referrer-Policy: strict-origin-when-cross-origin
+  Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+  Permissions-Policy: geolocation=(), microphone=(), camera=(), payment=()


### PR DESCRIPTION
Added `Strict-Transport-Security` and `Permissions-Policy` to `_headers` to improve the security posture of the Cloudflare Pages application. This enforces HTTPS to mitigate downgrade attacks and globally restricts sensitive browser APIs to adhere to the principle of least privilege.

---
*PR created automatically by Jules for task [13619191492294514028](https://jules.google.com/task/13619191492294514028) started by @ryusoh*