### PR TITLE
TestPilot: add coverage for transaction table utilities

### DIFF
--- a/.jules/testpilot.md
+++ b/.jules/testpilot.md
@@ -23,3 +23,12 @@ Result: Targeted 5 edge cases for 'bayes', 'displayCache' and 'assetClasses' fun
 What: Added missing test coverage in `tests/js/ui/tableGlassEffect.test.js`, `tests/js/ui/nav_prefetch.test.js`, and `tests/js/utils/date.test.js`.
 Coverage: +3 previously missing coverage points addressed and covered edge cases.
 Result: `npm run verify:all` passes successfully, pushing overall coverage closer to 100%. No production logic was modified.
+
+## 2024-05-22
+
+What: Improved test coverage for `js/transactions/table/filter.js`, `js/transactions/table/sort.js`, and `js/transactions/table/parser.js`.
+Coverage: Brought all three files to nearly 100% test coverage using newly added Jest test suites targeting edge cases, empty/null states, and logic paths.
+Result: Targeted `js/transactions/table` component directory which had significantly low coverage, expanding coverage without modifying any production code.
+
+## 2024-05-22 - Transaction Table Parsing & Sorting
+**Learning:** For standalone user input parsing matching ticker logic (e.g., `js/transactions/table/parser.js`), test cases must account for edge cases where general standalone text happens to mimic a cleaned ticker format (e.g. `123AAPL` resolving into a valid ticker token even if unintended), ensuring strict deterministic parsing without crashing.

--- a/tests/js/transactions/filter.test.js
+++ b/tests/js/transactions/filter.test.js
@@ -1,0 +1,216 @@
+import { applyDateRangeFilter, applySecurityFilter, applyValueFilters, applyTextFilter } from '@js/transactions/table/filter.js';
+import * as utils from '@js/transactions/utils.js';
+import * as parser from '@js/transactions/table/parser.js';
+import * as dateUtils from '@utils/date.js';
+
+jest.mock('@js/transactions/utils.js');
+jest.mock('@js/transactions/table/parser.js');
+jest.mock('@utils/date.js');
+
+describe('applyDateRangeFilter', () => {
+    const transactions = [
+        { tradeDate: '2023-01-01' },
+        { tradeDate: '2023-01-15' },
+        { tradeDate: '2023-01-31' },
+    ];
+
+    beforeEach(() => {
+        jest.resetAllMocks();
+        dateUtils.normalizeDateOnly.mockImplementation((date) => date);
+    });
+
+    it('returns all transactions when range is null', () => {
+        expect(applyDateRangeFilter(transactions, null, null)).toEqual(transactions);
+    });
+
+    it('filters transactions after start date', () => {
+        const start = new Date('2023-01-10').getTime();
+        expect(applyDateRangeFilter(transactions, start, null)).toEqual([
+            { tradeDate: '2023-01-15' },
+            { tradeDate: '2023-01-31' },
+        ]);
+    });
+
+    it('filters transactions before end date', () => {
+        const end = new Date('2023-01-20').getTime();
+        expect(applyDateRangeFilter(transactions, null, end)).toEqual([
+            { tradeDate: '2023-01-01' },
+            { tradeDate: '2023-01-15' },
+        ]);
+    });
+
+    it('filters transactions within range', () => {
+        const start = new Date('2023-01-10').getTime();
+        const end = new Date('2023-01-20').getTime();
+        expect(applyDateRangeFilter(transactions, start, end)).toEqual([
+            { tradeDate: '2023-01-15' },
+        ]);
+    });
+
+    it('handles invalid dates by excluding them', () => {
+        const badTransactions = [...transactions, { tradeDate: 'invalid' }];
+        const start = new Date('2023-01-10').getTime();
+        expect(applyDateRangeFilter(badTransactions, start, null)).toEqual([
+            { tradeDate: '2023-01-15' },
+            { tradeDate: '2023-01-31' },
+        ]);
+    });
+
+    it('handles falsy normalized dates by falling back to transaction tradeDate', () => {
+        dateUtils.normalizeDateOnly.mockReturnValue(null);
+        const start = new Date('2023-01-10').getTime();
+        expect(applyDateRangeFilter(transactions, start, null)).toEqual([
+            { tradeDate: '2023-01-15' },
+            { tradeDate: '2023-01-31' },
+        ]);
+    });
+});
+
+describe('applySecurityFilter', () => {
+    const transactions = [
+        { security: 'AAPL' },
+        { security: 'MSFT' },
+        { security: 'GOOGL' },
+    ];
+
+    beforeEach(() => {
+        jest.resetAllMocks();
+        parser.normalizeTickerToken.mockImplementation(t => t ? t.toUpperCase() : null);
+    });
+
+    it('returns all transactions when no security or multiTickerSet is provided', () => {
+        expect(applySecurityFilter(transactions, {}, null)).toEqual(transactions);
+    });
+
+    it('filters by single security via normalized token', () => {
+        expect(applySecurityFilter(transactions, { security: 'aapl' }, null)).toEqual([
+            { security: 'AAPL' },
+        ]);
+    });
+
+    it('filters by single security via fallback uppercase', () => {
+        parser.normalizeTickerToken.mockReturnValue(null);
+        expect(applySecurityFilter(transactions, { security: 'aapl' }, null)).toEqual([
+            { security: 'AAPL' },
+        ]);
+    });
+
+    it('filters by multiTickerSet via normalized token', () => {
+        const set = new Set(['AAPL', 'MSFT']);
+        expect(applySecurityFilter(transactions, {}, set)).toEqual([
+            { security: 'AAPL' },
+            { security: 'MSFT' },
+        ]);
+    });
+
+    it('filters by multiTickerSet via fallback uppercase', () => {
+        parser.normalizeTickerToken.mockReturnValue(null);
+        const set = new Set(['AAPL', 'MSFT']);
+        expect(applySecurityFilter(transactions, {}, set)).toEqual([
+            { security: 'AAPL' },
+            { security: 'MSFT' },
+        ]);
+    });
+
+    it('filters by both single security and multiTickerSet', () => {
+        const set = new Set(['AAPL', 'MSFT']);
+        expect(applySecurityFilter(transactions, { security: 'AAPL' }, set)).toEqual([
+            { security: 'AAPL' },
+            { security: 'MSFT' },
+        ]);
+    });
+});
+
+describe('applyValueFilters', () => {
+    const transactions = [
+        { orderType: 'Buy', netAmount: 100, tradeDate: '2023-01-01', security: 'AAPL' },
+        { orderType: 'Sell', netAmount: -50, tradeDate: '2023-01-02', security: 'MSFT' },
+        { orderType: 'Buy', netAmount: 200, tradeDate: '2023-01-03', security: 'GOOGL' },
+    ];
+
+    beforeEach(() => {
+        jest.resetAllMocks();
+        utils.convertValueToCurrency.mockImplementation((val) => val);
+        parser.matchesAssetClass.mockImplementation((sec, cls) => {
+            if (cls === 'etf') {return sec === 'VOO';}
+            if (cls === 'stock') {return sec !== 'VOO';}
+            return true;
+        });
+    });
+
+    it('returns all transactions when no filters are applied', () => {
+        expect(applyValueFilters(transactions, { min: null, max: null }, 'USD')).toEqual(transactions);
+    });
+
+    it('filters by min net amount absolute value', () => {
+        expect(applyValueFilters(transactions, { min: 75, max: null }, 'USD')).toEqual([
+            { orderType: 'Buy', netAmount: 100, tradeDate: '2023-01-01', security: 'AAPL' },
+            { orderType: 'Buy', netAmount: 200, tradeDate: '2023-01-03', security: 'GOOGL' },
+        ]);
+    });
+
+    it('filters by max net amount absolute value', () => {
+        expect(applyValueFilters(transactions, { min: null, max: 150 }, 'USD')).toEqual([
+            { orderType: 'Buy', netAmount: 100, tradeDate: '2023-01-01', security: 'AAPL' },
+            { orderType: 'Sell', netAmount: -50, tradeDate: '2023-01-02', security: 'MSFT' },
+        ]);
+    });
+
+    it('filters by min and max net amount absolute value', () => {
+        expect(applyValueFilters(transactions, { min: 75, max: 150 }, 'USD')).toEqual([
+            { orderType: 'Buy', netAmount: 100, tradeDate: '2023-01-01', security: 'AAPL' },
+        ]);
+    });
+
+    it('filters by order type ignoring case', () => {
+        expect(applyValueFilters(transactions, { min: null, max: null, type: 'buy' }, 'USD')).toEqual([
+            { orderType: 'Buy', netAmount: 100, tradeDate: '2023-01-01', security: 'AAPL' },
+            { orderType: 'Buy', netAmount: 200, tradeDate: '2023-01-03', security: 'GOOGL' },
+        ]);
+    });
+
+    it('filters by asset class', () => {
+        const txs = [
+            ...transactions,
+            { orderType: 'Buy', netAmount: 300, tradeDate: '2023-01-04', security: 'VOO' },
+        ];
+        expect(applyValueFilters(txs, { min: null, max: null, assetClass: 'etf' }, 'USD')).toEqual([
+            { orderType: 'Buy', netAmount: 300, tradeDate: '2023-01-04', security: 'VOO' },
+        ]);
+    });
+
+    it('ignores invalid min max', () => {
+        expect(applyValueFilters(transactions, { min: NaN, max: NaN }, 'USD')).toEqual(transactions);
+    });
+});
+
+describe('applyTextFilter', () => {
+    const transactions = [
+        { security: 'AAPL', orderType: 'Buy', tradeDate: '2023-01-01' },
+        { security: 'MSFT', orderType: 'Sell', tradeDate: '2023-01-02' },
+        { security: 'GOOGL', orderType: 'Buy', tradeDate: '2023-01-03' },
+    ];
+
+    it('returns all transactions when term is empty', () => {
+        expect(applyTextFilter(transactions, '')).toEqual(transactions);
+        expect(applyTextFilter(transactions, null)).toEqual(transactions);
+    });
+
+    it('filters by security', () => {
+        expect(applyTextFilter(transactions, 'aap')).toEqual([
+            { security: 'AAPL', orderType: 'Buy', tradeDate: '2023-01-01' },
+        ]);
+    });
+
+    it('filters by order type', () => {
+        expect(applyTextFilter(transactions, 'sell')).toEqual([
+            { security: 'MSFT', orderType: 'Sell', tradeDate: '2023-01-02' },
+        ]);
+    });
+
+    it('filters by trade date', () => {
+        expect(applyTextFilter(transactions, '01-03')).toEqual([
+            { security: 'GOOGL', orderType: 'Buy', tradeDate: '2023-01-03' },
+        ]);
+    });
+});

--- a/tests/js/transactions/parser.test.js
+++ b/tests/js/transactions/parser.test.js
@@ -1,0 +1,165 @@
+import { normalizeTickerToken, parseCommandPalette, deriveCompositionTickerFilters, matchesAssetClass } from '@js/transactions/table/parser.js';
+import * as config from '@js/config.js';
+
+jest.mock('@js/config.js');
+
+describe('normalizeTickerToken', () => {
+    it('normalizes standard tokens', () => {
+        expect(normalizeTickerToken('AAPL')).toBe('AAPL');
+        expect(normalizeTickerToken('msft')).toBe('MSFT');
+        expect(normalizeTickerToken('123AAPL')).toBe('123AAPL');
+    });
+
+    it('resolves aliases', () => {
+        expect(normalizeTickerToken('BRK')).toBe('BRKB');
+        expect(normalizeTickerToken('BRK-B')).toBe('BRKB');
+        expect(normalizeTickerToken('BRKB')).toBe('BRKB');
+    });
+
+    it('removes special characters except hyphens', () => {
+        expect(normalizeTickerToken('AAPL.US')).toBe('AAPLUS');
+        expect(normalizeTickerToken('BRK/B')).toBe('BRKB');
+        expect(normalizeTickerToken('TEST-123')).toBe('TEST-123');
+    });
+
+    it('returns null for empty or invalid tokens', () => {
+        expect(normalizeTickerToken('')).toBeNull();
+        expect(normalizeTickerToken('  ')).toBeNull();
+        expect(normalizeTickerToken(null)).toBeNull();
+        expect(normalizeTickerToken(undefined)).toBeNull();
+        expect(normalizeTickerToken('12345')).toBeNull(); // No letters
+        expect(normalizeTickerToken('!@#$')).toBeNull();
+    });
+});
+
+describe('parseCommandPalette - key/value parsing', () => {
+    it('parses type command', () => {
+        const result = parseCommandPalette('type:buy some text');
+        expect(result.commands.type).toBe('buy');
+    });
+
+    it('parses security command', () => {
+        const result = parseCommandPalette('security:AAPL some text');
+        expect(result.commands.security).toBe('AAPL');
+    });
+
+    it('parses s command (alias for security)', () => {
+        const result = parseCommandPalette('s:AAPL some text');
+        expect(result.commands.security).toBe('AAPL');
+    });
+
+    it('parses min and max commands', () => {
+        const result = parseCommandPalette('min:100 max:500 text');
+        expect(result.commands.min).toBe(100);
+        expect(result.commands.max).toBe(500);
+    });
+
+    it('parses asset class command', () => {
+        const result = parseCommandPalette('asset:etf class:stock');
+        expect(result.commands.assetClass).toBe('stock'); // The last one wins
+    });
+
+    it('parses direct etf/stock keywords', () => {
+        const result = parseCommandPalette('etf');
+        expect(result.commands.assetClass).toBe('etf');
+    });
+
+    it('identifies standalone tickers', () => {
+        const result = parseCommandPalette('AAPL text MSFT');
+        // 'text' parses as TEXT because it is letters only, which normalized as a valid ticker format
+        // wait... wait, 'text' normalized is TEXT. So it considers it a ticker.
+        expect(result.commands.tickers).toEqual(['AAPL', 'TEXT', 'MSFT']);
+    });
+
+    it('handles type sell', () => {
+        const result = parseCommandPalette('type:sell');
+        expect(result.commands.type).toBe('sell');
+    });
+
+    it('handles invalid type', () => {
+        const result = parseCommandPalette('type:invalid');
+        expect(result.commands.type).toBeNull();
+    });
+
+    it('handles invalid min max', () => {
+        const result = parseCommandPalette('min:invalid max:invalid');
+        expect(result.commands.min).toBeNaN();
+        expect(result.commands.max).toBeNaN();
+    });
+
+    it('handles standalone text that is not a ticker', () => {
+        const result = parseCommandPalette('12345 !@#$');
+        expect(result.text).toBe('12345 !@#$');
+        expect(result.commands.tickers).toEqual([]);
+    });
+
+    it('handles unknown key:val pairs where token is not a valid ticker', () => {
+        const result = parseCommandPalette('unknown:val!');
+        // processKeyValToken receives token='unknown:val!'
+        // normalizeTickerToken('unknown:val!') returns 'UNKNOWNVAL'
+        // So 'unknown:val!' is treated as a valid ticker
+        expect(result.commands.tickers).toEqual(['UNKNOWNVAL']);
+    });
+
+    it('handles unknown key:val pairs where key is a ticker', () => {
+        const result = parseCommandPalette('AAPL:123');
+        // AAPL:123 normalizes to AAPL123
+        expect(result.commands.tickers).toEqual(['AAPL123']);
+    });
+});
+
+describe('deriveCompositionTickerFilters', () => {
+    it('combines security command and text tickers', () => {
+        const commands = { security: 'AAPL' };
+        const text = 'MSFT GOOGL';
+        expect(deriveCompositionTickerFilters(text, commands)).toEqual(['AAPL', 'MSFT', 'GOOGL']);
+    });
+
+    it('deduplicates tickers', () => {
+        const commands = { security: 'AAPL' };
+        const text = 'AAPL MSFT MSFT';
+        expect(deriveCompositionTickerFilters(text, commands)).toEqual(['AAPL', 'MSFT']);
+    });
+
+    it('handles missing commands', () => {
+        expect(deriveCompositionTickerFilters('AAPL')).toEqual(['AAPL']);
+    });
+
+    it('handles missing text', () => {
+        const commands = { security: 'AAPL' };
+        expect(deriveCompositionTickerFilters('', commands)).toEqual(['AAPL']);
+        expect(deriveCompositionTickerFilters(null, commands)).toEqual(['AAPL']);
+    });
+});
+
+describe('matchesAssetClass', () => {
+    beforeEach(() => {
+        jest.resetAllMocks();
+    });
+
+    it('returns true if no desired class is specified', () => {
+        expect(matchesAssetClass('AAPL', null)).toBe(true);
+        expect(matchesAssetClass('AAPL', '')).toBe(true);
+    });
+
+    it('returns true if security is not a string', () => {
+        expect(matchesAssetClass(123, 'etf')).toBe(true);
+    });
+
+    it('matches etf', () => {
+        config.getHoldingAssetClass.mockReturnValue('etf');
+        expect(matchesAssetClass('VOO', 'etf')).toBe(true);
+        expect(matchesAssetClass('VOO', 'stock')).toBe(false);
+    });
+
+    it('matches stock', () => {
+        config.getHoldingAssetClass.mockReturnValue('stock');
+        expect(matchesAssetClass('AAPL', 'stock')).toBe(true);
+        expect(matchesAssetClass('AAPL', 'etf')).toBe(false);
+    });
+
+    it('returns true for unknown asset classes if not etf', () => {
+        config.getHoldingAssetClass.mockReturnValue('unknown');
+        expect(matchesAssetClass('CASH', 'stock')).toBe(true);
+    });
+});

--- a/tests/js/transactions/sort.test.js
+++ b/tests/js/transactions/sort.test.js
@@ -1,0 +1,83 @@
+import { sortTransactions } from '@js/transactions/table/sort.js';
+import * as utils from '@js/transactions/utils.js';
+
+jest.mock('@js/transactions/utils.js');
+
+describe('sortTransactions', () => {
+    let transactions;
+
+    beforeEach(() => {
+        jest.resetAllMocks();
+        utils.convertValueToCurrency.mockImplementation((val) => val);
+
+        transactions = [
+            { transactionId: '1', security: 'AAPL', quantity: '10', price: 150, netAmount: -1500, tradeDate: '2023-01-01' },
+            { transactionId: '2', security: 'MSFT', quantity: '5', price: 250, netAmount: -1250, tradeDate: '2023-01-02' },
+            { transactionId: '3', security: 'GOOGL', quantity: '20', price: 100, netAmount: -2000, tradeDate: '2023-01-03' },
+            { transactionId: '4', security: 'AAPL', quantity: '15', price: 155, netAmount: -2325, tradeDate: '2023-01-04' },
+            { transactionId: '5', security: 'TSLA', quantity: '10', price: 200, netAmount: -2000, tradeDate: '2023-01-03' },
+        ];
+    });
+
+    it('sorts by security asc', () => {
+        sortTransactions(transactions, { column: 'security', order: 'asc' }, 'USD');
+        expect(transactions.map(t => t.transactionId)).toEqual(['4', '1', '3', '2', '5']);
+    });
+
+    it('sorts by security desc', () => {
+        sortTransactions(transactions, { column: 'security', order: 'desc' }, 'USD');
+        expect(transactions.map(t => t.transactionId)).toEqual(['5', '2', '3', '4', '1']);
+    });
+
+    it('sorts by quantity asc', () => {
+        sortTransactions(transactions, { column: 'quantity', order: 'asc' }, 'USD');
+        expect(transactions.map(t => t.transactionId)).toEqual(['2', '5', '1', '4', '3']);
+    });
+
+    it('sorts by quantity desc', () => {
+        sortTransactions(transactions, { column: 'quantity', order: 'desc' }, 'USD');
+        expect(transactions.map(t => t.transactionId)).toEqual(['3', '4', '5', '1', '2']);
+    });
+
+    it('sorts by price asc', () => {
+        sortTransactions(transactions, { column: 'price', order: 'asc' }, 'USD');
+        expect(transactions.map(t => t.transactionId)).toEqual(['3', '1', '4', '5', '2']);
+    });
+
+    it('sorts by price desc', () => {
+        sortTransactions(transactions, { column: 'price', order: 'desc' }, 'USD');
+        expect(transactions.map(t => t.transactionId)).toEqual(['2', '5', '4', '1', '3']);
+    });
+
+    it('sorts by netAmount (absolute) asc', () => {
+        sortTransactions(transactions, { column: 'netAmount', order: 'asc' }, 'USD');
+        // JS sort is stable in modern environments, so 3 and 5 will preserve relative order when ties are perfectly 0.
+        // Let's assume order is 3, 5 for the tie
+        expect(transactions.map(t => t.transactionId)).toEqual(['2', '1', '3', '5', '4']);
+    });
+
+    it('sorts by netAmount desc', () => {
+        sortTransactions(transactions, { column: 'netAmount', order: 'desc' }, 'USD');
+        expect(transactions.map(t => t.transactionId)).toEqual(['4', '3', '5', '1', '2']);
+    });
+
+    it('sorts by tradeDate asc', () => {
+        sortTransactions(transactions, { column: 'tradeDate', order: 'asc' }, 'USD');
+        // tradeDate tiebreaker goes to transactionId asc
+        // 3 and 5 have the same trade date.
+        // transactionId order asc means '3' < '5', so 3 comes first.
+        expect(transactions.map(t => t.transactionId)).toEqual(['1', '2', '3', '5', '4']);
+    });
+
+    it('sorts by tradeDate desc', () => {
+        sortTransactions(transactions, { column: 'tradeDate', order: 'desc' }, 'USD');
+        // tradeDate tiebreaker goes to transactionId desc (when tradeDate is order=desc, idOrder=desc)
+        // 3 and 5 have same trade date. desc means '5' > '3' so 5 comes before 3.
+        expect(transactions.map(t => t.transactionId)).toEqual(['4', '5', '3', '2', '1']);
+    });
+
+    it('uses tradeDate as default column', () => {
+        sortTransactions(transactions, { column: 'unknown', order: 'asc' }, 'USD');
+        expect(transactions.map(t => t.transactionId)).toEqual(['1', '2', '3', '5', '4']);
+    });
+});


### PR DESCRIPTION
TestPilot: add coverage for transaction table utilities

Added Jest unit tests for `js/transactions/table/filter.js`, `js/transactions/table/sort.js`, and `js/transactions/table/parser.js` to cover edge cases, null states, and tiebreakers, bringing their coverage towards 100%. Recorded findings in `.jules/testpilot.md`.

---
*PR created automatically by Jules for task [15473373252354180962](https://jules.google.com/task/15473373252354180962) started by @ryusoh*