### PR TITLE
⚡ Bolt: Replace Array.from().reduce() with direct for...of loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -102,3 +102,8 @@
 
 **Learning:** Allocating arrays via `.slice()` inside an outer loop over all data points in filtering/smoothing logic (like Savitzky-Golay) causes O(N\*W) allocations resulting in garbage collection pressure.
 **Action:** Avoid `.slice()` and pass the original array with start/end indices to helper functions to compute values in O(1) space per iteration.
+
+## $(date +%Y-%m-%d) - Array.from().reduce() overhead on Iterables
+
+**Learning:** When summing or accumulating values from an iterable (e.g., `Map.values()` or `Set.values()`), using `Array.from(iterable).reduce(...)` allocates an unnecessary intermediate array, which causes garbage collection (GC) pressure.
+**Action:** Always replace `Array.from(iterable).reduce(...)` with a direct `for...of` loop over the iterable to prevent memory allocation and reduce overhead.

--- a/js/transactions/calculations.js
+++ b/js/transactions/calculations.js
@@ -131,10 +131,12 @@ export function computeRunningTotals(transactions, splitHistory) {
         });
     });
 
-    const totalRealizedGain = Array.from(securityStates.values()).reduce(
-        (sum, s) => sum + s.totalRealizedGain,
-        0
-    );
+    // Bolt: Use direct for...of loop over Map.values() instead of Array.from().reduce()
+    // to avoid intermediate array allocation and reduce garbage collection overhead
+    let totalRealizedGain = 0;
+    for (const s of securityStates.values()) {
+        totalRealizedGain += s.totalRealizedGain;
+    }
     runningTotalsById.totalRealizedGain = totalRealizedGain;
 
     return runningTotalsById;


### PR DESCRIPTION
💡 What: Refactored `Array.from(securityStates.values()).reduce(...)` into a single `for...of` loop over `securityStates.values()`.
🎯 Why: Creating an intermediate array using `Array.from()` to then `reduce()` over it causes O(N) allocation and garbage collection pressure, slowing down the computation, especially in high frequency paths.
📊 Impact: Expected to reduce execution time and memory footprint (by avoiding intermediate array allocation) when computing running totals for securities.
🔬 Measurement: Benchmarks or flamegraph profiles around the `computeRunningTotals` method will show lower time spent in array allocation and GC runs.

---
*PR created automatically by Jules for task [9160375065452968720](https://jules.google.com/task/9160375065452968720) started by @ryusoh*