### PR TITLE
feat: add text support to custom cursor on hover

### DIFF
--- a/css/cursor.css
+++ b/css/cursor.css
@@ -113,3 +113,27 @@ html.force-hide-cursor .custom-cursor {
 footer a {
     cursor: none !important;
 }
+
+.custom-cursor__core.has-text {
+    background: #fff;
+    border: none;
+}
+
+.custom-cursor__text {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%) scale(0.33);
+    color: #000;
+    font-family: 'JetBrains Mono ExtraBold', monospace;
+    font-size: 8px;
+    font-weight: 800;
+    text-transform: uppercase;
+    opacity: 0;
+    white-space: nowrap;
+    transition: opacity 0.15s ease;
+}
+
+.custom-cursor__core.has-text .custom-cursor__text {
+    opacity: 1;
+}

--- a/js/vendor/cursor.js
+++ b/js/vendor/cursor.js
@@ -181,6 +181,11 @@ export class CustomCursor {
         this.core = document.createElement('div');
         this.core.className = `${className}__core`;
         this.core.style.transformOrigin = '50% 50%';
+
+        this.text = document.createElement('div');
+        this.text.className = `${className}__text`;
+        this.core.appendChild(this.text);
+
         this.element.appendChild(this.core);
 
         const storedPosition = readStoredCursorPosition();
@@ -239,13 +244,24 @@ export class CustomCursor {
         }
     }
 
-    onMouseEnter() {
+    onMouseEnter(event) {
         this.core.classList.add(this.hoverClass);
-        this.coords.scale.current = this.hoverScale;
+        let text = event.currentTarget ? event.currentTarget.getAttribute('data-cursor-text') : null;
+        if (!text && event.currentTarget && event.currentTarget.tagName.toLowerCase() === 'a') text = 'GO';
+        if (text) {
+            this.core.classList.add('has-text');
+            this.text.textContent = text;
+            this.coords.scale.current = 4;
+        } else {
+            this.core.classList.remove('has-text');
+            this.text.textContent = '';
+            this.coords.scale.current = this.hoverScale;
+        }
     }
 
     onMouseLeave() {
         this.core.classList.remove(this.hoverClass);
+        this.core.classList.remove('has-text');
         this.coords.scale.current = 1;
     }
 


### PR DESCRIPTION
Added text support to the custom cursor, inspired by creative design elements. When hovering over a link, the cursor expands and displays the text 'GO' inside a white circle. It also supports custom text via the `data-cursor-text` attribute.

- Modified `js/vendor/cursor.js` to create a child `div` for the text and handle adding/removing the text and `has-text` class on mouse enter/leave.
- Updated `css/cursor.css` to style the expanded white cursor background and position the text correctly, using `transform: scale(0.33)` to counteract the parent's `scale(4)` expansion, ensuring the text is crisp and correctly sized.

---
*PR created automatically by Jules for task [8145030987240094675](https://jules.google.com/task/8145030987240094675) started by @ryusoh*