### PR TITLE
🎨 Palette: Add keyboard accessibility to scrollable analysis columns

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -58,3 +58,9 @@
 **Learning:** When adding hover states (`:hover`) to interactive elements like buttons, failing to scope the selector can result in disabled buttons continuing to show hover effects (like background color or shadow changes). This provides misleading visual cues to users, implying the element is interactive when it is not.
 
 **Action:** Always append `:not(:disabled)` to `:hover` pseudo-classes on interactive elements (e.g., `.btn:hover:not(:disabled)`) to ensure hover styling is only applied when the element is actually usable.
+
+## 2026-04-18 - Nested Grid Layout Scrollable Columns Accessibility
+
+**Learning:** When using CSS Grid or Flexbox to create complex dashboard layouts with independently scrollable columns (e.g., `overflow-y: auto` on `.left-col` or `.right-col`), these containers must be explicitly focusable. Otherwise, keyboard users cannot scroll their contents if the content exceeds the viewport height.
+
+**Action:** Always add `tabindex="0"` and an appropriate `:focus-visible` styling (e.g., `outline: 2px solid rgba(255, 255, 255, 0.5)`) to structurally scrollable column containers in complex layouts to enable keyboard scrolling.

--- a/analysis/index.html
+++ b/analysis/index.html
@@ -37,7 +37,7 @@
                     <!-- The header and summary stats grid have been moved to the top-nav -->
 
                     <div class="output-grid">
-                        <div class="left-col">
+                        <div class="left-col" tabindex="0">
                             <article class="scenario-block">
                                 <div class="block-header">
                                     <h3>Scenario Outcomes</h3>
@@ -51,7 +51,7 @@
                             </article>
                         </div>
 
-                        <div class="right-col">
+                        <div class="right-col" tabindex="0">
                             <article class="risk-sim">
                                 <div class="block-header">
                                     <h3>Monte Carlo Risk Simulation</h3>

--- a/css/analysis-proto.css
+++ b/css/analysis-proto.css
@@ -236,6 +236,13 @@ body {
     padding-right: 5px;
 }
 
+.left-col:focus-visible,
+.right-col:focus-visible {
+    outline: 2px solid rgba(255, 255, 255, 0.5);
+    outline-offset: -2px;
+    border-radius: 4px;
+}
+
 .right-col {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
💡 What: Added `tabindex="0"` and a `:focus-visible` outline to the left and right columns on the analysis page.
🎯 Why: These containers act as independent scroll areas (`overflow-y: auto`). Without being focusable, keyboard-only users have no way to scroll the content inside them if it extends beyond the visible area.
📸 Before/After: Verified visually via Playwright that tab navigation now correctly cycles into the containers and highlights them with a subtle 2px white focus ring.
♿ Accessibility: Ensures WCAG compliance for scrollable regions by allowing keyboard users to focus and navigate content using arrow keys.

---
*PR created automatically by Jules for task [7927909610975202747](https://jules.google.com/task/7927909610975202747) started by @ryusoh*