### PR TITLE
Palette: Add visual empty state for terminal chart

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -64,3 +64,9 @@
 **Learning:** When using CSS Grid or Flexbox to create complex dashboard layouts with independently scrollable columns (e.g., `overflow-y: auto` on `.left-col` or `.right-col`), these containers must be explicitly focusable. Otherwise, keyboard users cannot scroll their contents if the content exceeds the viewport height.
 
 **Action:** Always add `tabindex="0"` and an appropriate `:focus-visible` styling (e.g., `outline: 2px solid rgba(255, 255, 255, 0.5)`) to structurally scrollable column containers in complex layouts to enable keyboard scrolling.
+
+## 2026-04-18 - Helpful Empty States for Charts
+
+**Learning:** When a chart (like the running amount chart) has no data available for the selected filters, leaving the canvas empty creates confusion as users might think the application is loading or broken. Providing an explicit empty state with an icon and clear message ("No transaction data available...") reassures the user.
+
+**Action:** Always provide visual empty states (`.chart-empty`) over canvas elements when the dataset is empty to improve user context and reassure them that the lack of data is expected.

--- a/css/terminal/chart.css
+++ b/css/terminal/chart.css
@@ -37,6 +37,33 @@
     filter: drop-shadow(0 12px 18px rgba(11, 15, 30, 0.75));
 }
 
+.chart-empty {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    text-align: center;
+    color: rgba(139, 148, 158, 0.8);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    pointer-events: none;
+}
+
+.chart-empty i {
+    font-size: 32px;
+    margin-bottom: 12px;
+    opacity: 0.6;
+}
+
+.chart-empty p {
+    margin: 0;
+    font-size: 14px;
+    font-weight: 500;
+}
+
 .table-header {
     display: flex;
     justify-content: space-between;

--- a/terminal/index.html
+++ b/terminal/index.html
@@ -164,7 +164,12 @@
                         role="img"
                         aria-label="Running amount chart"
                     ></canvas>
-                    <div class="chart-empty" id="runningAmountEmpty" style="display: none"></div>
+                    <div class="chart-empty" id="runningAmountEmpty" style="display: none">
+                        <div class="chart-empty-content">
+                            <i class="fa fa-line-chart" aria-hidden="true"></i>
+                            <p>No transaction data available for the selected range.</p>
+                        </div>
+                    </div>
                 </div>
                 <div class="chart-legend"></div>
             </section>


### PR DESCRIPTION
💡 What: Added an explicit empty state overlay (`.chart-empty`) with an icon and message for the terminal's running amount chart.
🎯 Why: When a user filters the chart to a state with no data, leaving the canvas completely blank creates confusion (users might think it's broken or still loading). Providing an explicit message reassures the user.
♿ Accessibility: The empty state has `aria-hidden="true"` on the decorative icon and `pointer-events: none` to avoid interfering with any underlying canvas interaction.

No new dependencies were added. The change uses the existing FontAwesome icons and is styled using existing design patterns.

---
*PR created automatically by Jules for task [15591735199789826923](https://jules.google.com/task/15591735199789826923) started by @ryusoh*