### PR TITLE
🎨 Palette: Add explicit visual empty state to terminal charts

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -64,3 +64,6 @@
 **Learning:** When using CSS Grid or Flexbox to create complex dashboard layouts with independently scrollable columns (e.g., `overflow-y: auto` on `.left-col` or `.right-col`), these containers must be explicitly focusable. Otherwise, keyboard users cannot scroll their contents if the content exceeds the viewport height.
 
 **Action:** Always add `tabindex="0"` and an appropriate `:focus-visible` styling (e.g., `outline: 2px solid rgba(255, 255, 255, 0.5)`) to structurally scrollable column containers in complex layouts to enable keyboard scrolling.
+## 2024-05-19 - Chart empty state visualization
+**Learning:** JS dynamically toggles `emptyState.style.display` for data visualizations but the empty state container had no inherent visual representation or UI design defined, leaving users staring at an uncommunicative layout.
+**Action:** Always provide explicit visual empty states with helpful guidance (like an icon and a text) and apply a frosted glass overlay (using backdrop-filter) to empty containers to prevent users from assuming the application is broken or stuck loading.

--- a/css/terminal/chart.css
+++ b/css/terminal/chart.css
@@ -37,6 +37,35 @@
     filter: drop-shadow(0 12px 18px rgba(11, 15, 30, 0.75));
 }
 
+.chart-empty {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    background: rgba(17, 17, 17, 0.6);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+    z-index: 10;
+    border-radius: 8px;
+    color: #8b949e;
+}
+
+.chart-empty i {
+    font-size: 32px;
+    margin-bottom: 12px;
+    opacity: 0.5;
+}
+
+.chart-empty p {
+    font-size: 14px;
+    margin: 0;
+}
+
 .table-header {
     display: flex;
     justify-content: space-between;

--- a/terminal/index.html
+++ b/terminal/index.html
@@ -164,7 +164,10 @@
                         role="img"
                         aria-label="Running amount chart"
                     ></canvas>
-                    <div class="chart-empty" id="runningAmountEmpty" style="display: none"></div>
+                    <div class="chart-empty" id="runningAmountEmpty" style="display: none">
+                        <i class="fa fa-line-chart" aria-hidden="true"></i>
+                        <p>No data available</p>
+                    </div>
                 </div>
                 <div class="chart-legend"></div>
             </section>


### PR DESCRIPTION
💡 What: The UX enhancement added explicit styling and content to the terminal's chart empty state (`.chart-empty`).
🎯 Why: It provides an explicit visual empty state overlay (icon and text) over a frosted glass effect, preventing users from assuming the chart is broken or stuck loading when no data is available.
📸 Before/After: Visual empty state is now explicitly rendered.
♿ Accessibility: Ensures clear communication of the application state.

---
*PR created automatically by Jules for task [12991357485126665166](https://jules.google.com/task/12991357485126665166) started by @ryusoh*