### PR TITLE
Palette: Disable spellcheck on terminal input

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -64,3 +64,7 @@
 **Learning:** When using CSS Grid or Flexbox to create complex dashboard layouts with independently scrollable columns (e.g., `overflow-y: auto` on `.left-col` or `.right-col`), these containers must be explicitly focusable. Otherwise, keyboard users cannot scroll their contents if the content exceeds the viewport height.
 
 **Action:** Always add `tabindex="0"` and an appropriate `:focus-visible` styling (e.g., `outline: 2px solid rgba(255, 255, 255, 0.5)`) to structurally scrollable column containers in complex layouts to enable keyboard scrolling.
+
+## 2026-04-21 - Terminal Input UX
+**Learning:** Terminal emulator text inputs natively receive browser spellcheck by default, which incorrectly flags commands and stock tickers as spelling errors with distracting red underlines, breaking UI immersion.
+**Action:** Always add `spellcheck="false"` to text inputs that act as CLIs or expect non-prose data to prevent native browser interference.

--- a/terminal/index.html
+++ b/terminal/index.html
@@ -146,6 +146,7 @@
                         id="terminalInput"
                         class="terminal-input"
                         autocomplete="off"
+                        spellcheck="false"
                         autofocus
                         aria-label="Terminal input"
                     />


### PR DESCRIPTION
- Added `spellcheck="false"` to the terminal input in `terminal/index.html` to prevent the browser from flagging CLI commands or stock tickers as misspelled words.
- This prevents distracting red squiggly underlines and preserves the terminal immersion.
- Added journal entry for this UX learning.

---
*PR created automatically by Jules for task [3536448502963768730](https://jules.google.com/task/3536448502963768730) started by @ryusoh*