### PR TITLE
Palette: Remove focus from structural layout containers

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -68,3 +68,7 @@
 ## 2026-04-21 - Terminal Input UX
 **Learning:** Terminal emulator text inputs natively receive browser spellcheck by default, which incorrectly flags commands and stock tickers as spelling errors with distracting red underlines, breaking UI immersion.
 **Action:** Always add `spellcheck="false"` to text inputs that act as CLIs or expect non-prose data to prevent native browser interference.
+
+## 2026-04-22 - Layout Containers Accessibility Pitfall
+**Learning:** Adding `tabindex="0"` to non-interactive structural or layout containers (like `.left-col` or `.right-col`) to make them scrollable is an accessibility anti-pattern. It creates confusing stops for screen reader users on elements that have no interactive purpose or semantic meaning.
+**Action:** Do not add `tabindex="0"` to non-interactive structural or layout layout containers. Let the user scroll naturally without forcing focus onto the layout structure itself.

--- a/analysis/index.html
+++ b/analysis/index.html
@@ -37,7 +37,7 @@
                     <!-- The header and summary stats grid have been moved to the top-nav -->
 
                     <div class="output-grid">
-                        <div class="left-col" tabindex="0">
+                        <div class="left-col">
                             <article class="scenario-block">
                                 <div class="block-header">
                                     <h3>Scenario Outcomes</h3>
@@ -51,7 +51,7 @@
                             </article>
                         </div>
 
-                        <div class="right-col" tabindex="0">
+                        <div class="right-col">
                             <article class="risk-sim">
                                 <div class="block-header">
                                     <h3>Monte Carlo Risk Simulation</h3>

--- a/css/analysis-proto.css
+++ b/css/analysis-proto.css
@@ -236,13 +236,6 @@ body {
     padding-right: 5px;
 }
 
-.left-col:focus-visible,
-.right-col:focus-visible {
-    outline: 2px solid rgba(255, 255, 255, 0.5);
-    outline-offset: -2px;
-    border-radius: 4px;
-}
-
 .right-col {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
This PR removes `tabindex="0"` from non-interactive layout containers (`.left-col` and `.right-col`) in the analysis view. These were previously added to enable scrolling, but adding focus directly to generic containers acts as an accessibility anti-pattern, creating unhelpful tab stops for keyboard users and screen readers. Associated `:focus-visible` CSS rules have been cleaned up, and a learning entry added to `.jules/palette.md`.

---
*PR created automatically by Jules for task [1586160592527570266](https://jules.google.com/task/1586160592527570266) started by @ryusoh*