### PR TITLE
Sentinel: [security improvement] Add Content-Security-Policy to _headers

### DIFF
--- a/_headers
+++ b/_headers
@@ -4,3 +4,4 @@
   Referrer-Policy: strict-origin-when-cross-origin
   Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
   Permissions-Policy: geolocation=(), microphone=(), camera=(), payment=()
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://unpkg.com https://cdn.bootcdn.net https://cdn.baomitu.com; font-src 'self' data: https://fonts.gstatic.com https://unpkg.com https://cdn.bootcdn.net https://cdn.baomitu.com; img-src 'self' data:; connect-src 'self' https://api.lyeutsaon.com; media-src 'self'; frame-src 'none'; object-src 'none';


### PR DESCRIPTION
Adds the `Content-Security-Policy` header to the `_headers` file.

**Severity:** MEDIUM
**Vulnerability:** While CSP was defined in HTML `<meta>` tags, defining security policies solely in meta tags can sometimes be bypassed or fail to cover all edge cases, and is generally less robust than enforcing them at the HTTP header level.
**Impact:** Enhances defense-in-depth by providing server-level CSP enforcement via Cloudflare Pages, ensuring robust protection against Cross-Site Scripting (XSS) and data injection attacks.
**Fix:** Added the `Content-Security-Policy` directive to `_headers` with the same rules applied in the `index.html`.
**Verification:** Ran `pnpm run verify:all` and checked the `_headers` file contents.

---
*PR created automatically by Jules for task [12979242891250607369](https://jules.google.com/task/12979242891250607369) started by @ryusoh*