### PR TITLE
Palette: Add explicit visual empty state for terminal charts

### DIFF
--- a/css/terminal/chart.css
+++ b/css/terminal/chart.css
@@ -37,6 +37,28 @@
     filter: drop-shadow(0 12px 18px rgba(11, 15, 30, 0.75));
 }
 
+.chart-empty {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    text-align: center;
+    color: #8b949e;
+    pointer-events: none;
+    z-index: 10;
+}
+
+.empty-state-content i {
+    font-size: 2em;
+    margin-bottom: 8px;
+    opacity: 0.5;
+}
+
+.empty-state-content p {
+    font-size: 14px;
+    margin: 0;
+}
+
 .table-header {
     display: flex;
     justify-content: space-between;

--- a/terminal/index.html
+++ b/terminal/index.html
@@ -165,7 +165,12 @@
                         role="img"
                         aria-label="Running amount chart"
                     ></canvas>
-                    <div class="chart-empty" id="runningAmountEmpty" style="display: none"></div>
+                    <div class="chart-empty" id="runningAmountEmpty" style="display: none">
+                        <div class="empty-state-content">
+                            <i class="fa fa-line-chart" aria-hidden="true"></i>
+                            <p>No chart data available</p>
+                        </div>
+                    </div>
                 </div>
                 <div class="chart-legend"></div>
             </section>


### PR DESCRIPTION
What: Added an explicit visual empty state overlay (icon and text) for terminal charts when no data is available.
Why: Prevents users from assuming the application is broken or stuck loading when a chart has no data to display (e.g., due to filtering or empty portfolio).
Impact: Visual overlay now appears dynamically inside the chart container.
Accessibility: The empty state utilizes aria-hidden on the icon to avoid redundant screen reader noise.

---
*PR created automatically by Jules for task [15032948544638559543](https://jules.google.com/task/15032948544638559543) started by @ryusoh*