### PR TITLE
Bolt: Optimize array allocations in PE chart renderer

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -132,3 +132,8 @@
 
 **Learning:** Using Array.from().map() combined with .every() on Sets or iterables allocates intermediate arrays and causes unnecessary GC pressure. Replacing with a direct for...of loop avoids this overhead.
 **Action:** Use direct loops on iterables with early exits when possible instead of converting to arrays for map/every/some operations.
+
+## 2026-04-25 - Pre-sizing Map Array Allocations
+
+**Learning:** When replacing `.map()` and `.forEach()` calls inside high-frequency rendering loops (like generating `coords` or `bmkPoints` in `pe.js`) with explicit iterations, using `.push()` can dynamically resize arrays and increase GC pressure.
+**Action:** Pre-allocate the final arrays to their exact required size (e.g., `const coords = new Array(series.length);`) and assign items by index (`coords[i] = ...`) to completely remove dynamic array resizing overhead and reduce total GC pauses in charting frames.

--- a/js/transactions/chart/renderers/pe.js
+++ b/js/transactions/chart/renderers/pe.js
@@ -393,10 +393,14 @@ export function drawPEChart(ctx, chartManager, timestamp) {
             ];
             const bmkColor = bmkGradientStops[1] || '#999';
             // Mountain fill for benchmark
-            const bmkCoords = bmkSeries.map((point) => ({
-                x: xScale(point.date.getTime()),
-                y: yScale(point.pe),
-            }));
+            const bmkCoords = new Array(bmkSeries.length);
+            for (let i = 0; i < bmkSeries.length; i += 1) {
+                const point = bmkSeries[i];
+                bmkCoords[i] = {
+                    x: xScale(point.date.getTime()),
+                    y: yScale(point.pe),
+                };
+            }
 
             const bmkGradient = ctx.createLinearGradient(
                 0,
@@ -410,7 +414,9 @@ export function drawPEChart(ctx, chartManager, timestamp) {
             ctx.beginPath();
             if (bmkCoords.length > 0) {
                 ctx.moveTo(bmkCoords[0].x, plotHeight + padding.top);
-                bmkCoords.forEach((p) => ctx.lineTo(p.x, p.y));
+                for (let i = 0; i < bmkCoords.length; i += 1) {
+                    ctx.lineTo(bmkCoords[i].x, bmkCoords[i].y);
+                }
                 ctx.lineTo(bmkCoords[bmkCoords.length - 1].x, plotHeight + padding.top);
             }
             ctx.closePath();
@@ -434,13 +440,12 @@ export function drawPEChart(ctx, chartManager, timestamp) {
             ctx.beginPath();
             ctx.lineWidth = Math.max(1, lineThickness - 0.5);
             ctx.globalAlpha = 0.8;
-            bmkCoords.forEach((coord, index) => {
-                if (index === 0) {
-                    ctx.moveTo(coord.x, coord.y);
-                } else {
-                    ctx.lineTo(coord.x, coord.y);
+            if (bmkCoords.length > 0) {
+                ctx.moveTo(bmkCoords[0].x, bmkCoords[0].y);
+                for (let i = 1; i < bmkCoords.length; i += 1) {
+                    ctx.lineTo(bmkCoords[i].x, bmkCoords[i].y);
                 }
-            });
+            }
             ctx.stroke();
             ctx.globalAlpha = 1.0;
 
@@ -559,7 +564,11 @@ export function drawPEChart(ctx, chartManager, timestamp) {
             }
 
             // Store for crosshair
-            const bmkPoints = bmkSeries.map((p) => ({ time: p.date.getTime(), value: p.pe }));
+            const bmkPoints = new Array(bmkSeries.length);
+            for (let i = 0; i < bmkSeries.length; i += 1) {
+                const p = bmkSeries[i];
+                bmkPoints[i] = { time: p.date.getTime(), value: p.pe };
+            }
             benchmarkRendered.push({
                 key: visibleBenchmarkKey,
                 color: bmkColor,
@@ -569,12 +578,16 @@ export function drawPEChart(ctx, chartManager, timestamp) {
         }
     }
 
-    const coords = series.map((point) => ({
-        x: xScale(point.date.getTime()),
-        y: yScale(point.pe),
-        time: point.date.getTime(),
-        value: point.pe,
-    }));
+    const coords = new Array(series.length);
+    for (let i = 0; i < series.length; i += 1) {
+        const point = series[i];
+        coords[i] = {
+            x: xScale(point.date.getTime()),
+            y: yScale(point.pe),
+            time: point.date.getTime(),
+            value: point.pe,
+        };
+    }
 
     // Mountain fill
     const baselineY = yScale(yMin);
@@ -599,13 +612,12 @@ export function drawPEChart(ctx, chartManager, timestamp) {
     }
     ctx.beginPath();
     ctx.lineWidth = lineThickness;
-    coords.forEach((coord, index) => {
-        if (index === 0) {
-            ctx.moveTo(coord.x, coord.y);
-        } else {
-            ctx.lineTo(coord.x, coord.y);
+    if (coords.length > 0) {
+        ctx.moveTo(coords[0].x, coords[0].y);
+        for (let i = 1; i < coords.length; i += 1) {
+            ctx.lineTo(coords[i].x, coords[i].y);
         }
-    });
+    }
     ctx.stroke();
 
     // --- Draw forward PE dashed line ---
@@ -713,7 +725,11 @@ export function drawPEChart(ctx, chartManager, timestamp) {
     }
 
     // --- Layout for crosshair ---
-    const pePoints = series.map((p) => ({ time: p.date.getTime(), value: p.pe }));
+    const pePoints = new Array(series.length);
+    for (let i = 0; i < series.length; i += 1) {
+        const p = series[i];
+        pePoints[i] = { time: p.date.getTime(), value: p.pe };
+    }
 
     chartLayouts.pe = {
         key: 'pe',


### PR DESCRIPTION
💡 What: Replaced O(N) Array .map() and .forEach() with direct for loops and pre-allocated arrays in PE chart drawing logic.\n🎯 Why: Using .map() and .forEach() on large datasets in rendering loops creates short-lived array allocations, causing GC pressure.\n📊 Impact: Reduces array allocations by O(N) per frame during PE chart rendering.\n🔬 Measurement: Run `npm run verify:all` and observe the PE chart loads without GC stutters.

---
*PR created automatically by Jules for task [13764354072006947644](https://jules.google.com/task/13764354072006947644) started by @ryusoh*