### PR TITLE
Palette: Remove tabindex from layout containers in analysis

### DIFF
--- a/analysis/index.html
+++ b/analysis/index.html
@@ -37,7 +37,7 @@
                     <!-- The header and summary stats grid have been moved to the top-nav -->
 
                     <div class="output-grid">
-                        <div class="left-col" tabindex="0">
+                        <div class="left-col">
                             <article class="scenario-block">
                                 <div class="block-header">
                                     <h3>Scenario Outcomes</h3>
@@ -51,7 +51,7 @@
                             </article>
                         </div>
 
-                        <div class="right-col" tabindex="0">
+                        <div class="right-col">
                             <article class="risk-sim">
                                 <div class="block-header">
                                     <h3>Monte Carlo Risk Simulation</h3>


### PR DESCRIPTION
💡 What: Removed `tabindex="0"` from the non-interactive structural `.left-col` and `.right-col` containers in `analysis/index.html`.
🎯 Why: Making layout containers natively focusable forces unnecessary and confusing tab stops for keyboard and screen reader users on elements that have no interactive meaning.
📸 Before/After: Visuals remain unchanged; keyboard navigation flow is significantly improved.
♿ Accessibility: Eliminates an accessibility anti-pattern where structural columns trapped focus, improving the overall semantic navigation structure.

---
*PR created automatically by Jules for task [16721697242375651788](https://jules.google.com/task/16721697242375651788) started by @ryusoh*