### PR TITLE
Bolt: Replace map().filter().map() chain with single loop in performance renderer

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -152,3 +152,7 @@
 
 **Learning:** Using chained `.map()` calls inside high-frequency rendering loops dynamically allocates new arrays on every frame, generating significant garbage collection (GC) pressure.
 **Action:** Replace `.map()` operations inside high-frequency rendering loops with a standard `for` loop and pre-allocated arrays using `new Array(length)` to avoid runtime memory allocations.
+## 2026-04-29 - Array .map().filter().map() chains in chart renderers
+
+**Learning:** Chaining `.map().filter().map()` inside `performance.js` and other chart renderers creates multiple intermediate short-lived arrays. In tight rendering loops or on large data structures, this leads to significant array allocation overhead, max call stack limits, and garbage collection (GC) pressure.
+**Action:** Replaced chained higher-order array methods with a single inline manual `for` loop. Iterate over the input array, check the condition, compute the mapped values, and push directly to a newly instantiated single output array. This reduces execution time and prevents unnecessary GC pauses.

--- a/js/transactions/chart/renderers/performance.js
+++ b/js/transactions/chart/renderers/performance.js
@@ -120,26 +120,31 @@ export async function drawPerformanceChart(ctx, chartManager, timestamp) {
     let normalizedSeriesToDraw = seriesToDraw.map(cloneSeries);
 
     if (filterFrom || filterTo) {
+        // Bolt: Replaced O(N) Array .map().filter().map() with a single inline loop
         normalizedSeriesToDraw = normalizedSeriesToDraw.map((series) => {
-            const filteredData = series.data
-                .map((d) => ({ ...d, date: parseLocalDate(d.date) }))
-                .filter((d) => {
-                    const pointDate = d.date;
-                    return (
-                        (!filterFrom || pointDate >= filterFrom) &&
-                        (!filterTo || pointDate <= filterTo)
-                    );
-                });
+            const normalizedData = [];
+            let startValue = 0;
+            let hasStartValue = false;
 
-            if (filteredData.length === 0) {
-                return { ...series, data: [] };
+            for (let j = 0; j < series.data.length; j++) {
+                const d = series.data[j];
+                const pointDate = parseLocalDate(d.date);
+
+                if (
+                    (!filterFrom || pointDate >= filterFrom) &&
+                    (!filterTo || pointDate <= filterTo)
+                ) {
+                    if (!hasStartValue) {
+                        startValue = d.value;
+                        hasStartValue = true;
+                    }
+                    normalizedData.push({
+                        ...d,
+                        date: pointDate,
+                        value: Number.isFinite(startValue) && startValue !== 0 ? d.value / startValue : 1,
+                    });
+                }
             }
-
-            const startValue = filteredData[0].value;
-            const normalizedData = filteredData.map((d) => ({
-                ...d,
-                value: Number.isFinite(startValue) && startValue !== 0 ? d.value / startValue : 1,
-            }));
 
             return {
                 ...series,


### PR DESCRIPTION
💡 What: Replaced a chained array operation (`.map().filter().map()`) with a single, inline manual `for` loop in `js/transactions/chart/renderers/performance.js`.
🎯 Why: Chained higher-order array methods dynamically allocate multiple intermediate short-lived arrays. In tight rendering loops (like chart rendering), this places heavy pressure on the garbage collector and causes latency.
📊 Impact: Eliminates O(N) intermediate array allocations and reduces GC pauses.
🔬 Measurement: Verify tests still pass and verify the performance chart still functions as expected.

---
*PR created automatically by Jules for task [12136947359676062204](https://jules.google.com/task/12136947359676062204) started by @ryusoh*