### PR TITLE
TestPilot: Add coverage for commands and viewUtils

### DIFF
--- a/tests/js/transactions/terminal/viewUtils.test.js
+++ b/tests/js/transactions/terminal/viewUtils.test.js
@@ -1,4 +1,5 @@
-import { isActiveChartVisible } from '../../../../js/transactions/terminal/viewUtils.js';
+import { isActiveChartVisible, ensureTransactionTableVisible, isTransactionTableVisible, getActiveChartSummaryText } from '../../../../js/transactions/terminal/viewUtils.js';
+import * as snapshotsModule from '../../../../js/transactions/terminal/snapshots.js';
 import { transactionState } from '../../../../js/transactions/state.js';
 
 describe('viewUtils - isActiveChartVisible', () => {
@@ -57,5 +58,224 @@ describe('viewUtils - isActiveChartVisible', () => {
             transactionState.activeChart = chartType;
             expect(isActiveChartVisible()).toBe(true);
         });
+    });
+});
+
+describe('viewUtils - ensureTransactionTableVisible', () => {
+    beforeEach(() => {
+        document.body.innerHTML = `
+            <div id="runningAmountSection" class=""></div>
+            <div class="table-responsive-container is-hidden"></div>
+        `;
+    });
+
+    it('should remove is-hidden from table-responsive-container and add to runningAmountSection', () => {
+        ensureTransactionTableVisible();
+        const table = document.querySelector('.table-responsive-container');
+        const section = document.getElementById('runningAmountSection');
+        expect(table.classList.contains('is-hidden')).toBe(false);
+        expect(section.classList.contains('is-hidden')).toBe(true);
+    });
+
+    it('should handle missing elements gracefully', () => {
+        document.body.innerHTML = '';
+        expect(() => ensureTransactionTableVisible()).not.toThrow();
+    });
+});
+
+describe('viewUtils - isTransactionTableVisible', () => {
+    it('returns false when table container does not exist', () => {
+        document.body.innerHTML = '';
+        expect(isTransactionTableVisible()).toBe(false);
+    });
+
+    it('returns false when table container is hidden', () => {
+        document.body.innerHTML = '<div class="table-responsive-container is-hidden"></div>';
+        expect(isTransactionTableVisible()).toBe(false);
+    });
+
+    it('returns true when table container is visible', () => {
+        document.body.innerHTML = '<div class="table-responsive-container"></div>';
+        expect(isTransactionTableVisible()).toBe(true);
+    });
+});
+
+describe('viewUtils - getActiveChartSummaryText', () => {
+    let compositionSpy;
+    let sectorsSpy;
+    let performanceSpy;
+    let fxSpy;
+    let contributionSpy;
+    let drawdownSpy;
+    let concentrationSpy;
+    let peSpy;
+    let rollingSpy;
+    let volatilitySpy;
+    let yieldSpy;
+    let betaSpy;
+    let geographySpy;
+    let marketcapSpy;
+
+    beforeEach(() => {
+        compositionSpy = jest.spyOn(snapshotsModule, 'getCompositionSnapshotLine').mockResolvedValue('composition text');
+        sectorsSpy = jest.spyOn(snapshotsModule, 'getSectorsSnapshotLine').mockResolvedValue('sectors text');
+        performanceSpy = jest.spyOn(snapshotsModule, 'getPerformanceSnapshotLine').mockReturnValue('performance text');
+        fxSpy = jest.spyOn(snapshotsModule, 'getFxSnapshotLine').mockReturnValue('fx text');
+        contributionSpy = jest.spyOn(snapshotsModule, 'getContributionSummaryText').mockResolvedValue('contribution text');
+        drawdownSpy = jest.spyOn(snapshotsModule, 'getDrawdownSnapshotLine').mockReturnValue('drawdown text');
+        concentrationSpy = jest.spyOn(snapshotsModule, 'getConcentrationSnapshotText').mockReturnValue('concentration text');
+        peSpy = jest.spyOn(snapshotsModule, 'getPESnapshotLine').mockResolvedValue('pe text');
+        rollingSpy = jest.spyOn(snapshotsModule, 'getRollingSnapshotLine').mockReturnValue('rolling text');
+        volatilitySpy = jest.spyOn(snapshotsModule, 'getVolatilitySnapshotLine').mockReturnValue('volatility text');
+        yieldSpy = jest.spyOn(snapshotsModule, 'getYieldSnapshotLine').mockResolvedValue('yield text');
+        betaSpy = jest.spyOn(snapshotsModule, 'getBetaSnapshotLine').mockResolvedValue('beta text');
+        geographySpy = jest.spyOn(snapshotsModule, 'getGeographySnapshotLine').mockResolvedValue('geography text');
+        marketcapSpy = jest.spyOn(snapshotsModule, 'getMarketcapSnapshotLine').mockResolvedValue('marketcap text');
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+        transactionState.activeChart = null;
+        transactionState.chartDateRange = null;
+    });
+
+    it('returns composition text for composition', async () => {
+        transactionState.activeChart = 'composition';
+        const res = await getActiveChartSummaryText();
+        expect(res).toBe('composition text');
+        expect(compositionSpy).toHaveBeenCalledWith();
+    });
+
+    it('returns composition text for compositionAbs', async () => {
+        transactionState.activeChart = 'compositionAbs';
+        const res = await getActiveChartSummaryText();
+        expect(res).toBe('composition text');
+        expect(compositionSpy).toHaveBeenCalledWith({ labelPrefix: 'Composition Abs' });
+    });
+
+    it('returns sectors text for sectors', async () => {
+        transactionState.activeChart = 'sectors';
+        const res = await getActiveChartSummaryText();
+        expect(res).toBe('sectors text');
+        expect(sectorsSpy).toHaveBeenCalledWith();
+    });
+
+    it('returns sectors text for sectorsAbs', async () => {
+        transactionState.activeChart = 'sectorsAbs';
+        const res = await getActiveChartSummaryText();
+        expect(res).toBe('sectors text');
+        expect(sectorsSpy).toHaveBeenCalledWith({ labelPrefix: 'Sectors Abs' });
+    });
+
+    it('returns performance text for performance', async () => {
+        transactionState.activeChart = 'performance';
+        const res = await getActiveChartSummaryText();
+        expect(res).toBe('performance text');
+        expect(performanceSpy).toHaveBeenCalledWith({ includeHidden: true });
+    });
+
+    it('returns fx text for fx', async () => {
+        transactionState.activeChart = 'fx';
+        const res = await getActiveChartSummaryText();
+        expect(res).toBe('fx text');
+        expect(fxSpy).toHaveBeenCalledWith();
+    });
+
+    it('returns contribution text for contribution', async () => {
+        transactionState.activeChart = 'contribution';
+        transactionState.chartDateRange = 'YTD';
+        const res = await getActiveChartSummaryText();
+        expect(res).toBe('contribution text');
+        expect(contributionSpy).toHaveBeenCalledWith('YTD');
+    });
+
+    it('returns drawdown text for drawdown', async () => {
+        transactionState.activeChart = 'drawdown';
+        const res = await getActiveChartSummaryText();
+        expect(res).toBe('drawdown text');
+        expect(drawdownSpy).toHaveBeenCalledWith({ includeHidden: true });
+    });
+
+    it('returns drawdown text for drawdownAbs', async () => {
+        transactionState.activeChart = 'drawdownAbs';
+        const res = await getActiveChartSummaryText();
+        expect(res).toBe('drawdown text');
+        expect(drawdownSpy).toHaveBeenCalledWith({ includeHidden: true, isAbsolute: true });
+    });
+
+    it('returns concentration text for concentration', async () => {
+        transactionState.activeChart = 'concentration';
+        const res = await getActiveChartSummaryText();
+        expect(res).toBe('concentration text');
+        expect(concentrationSpy).toHaveBeenCalledWith();
+    });
+
+    it('returns pe text for pe', async () => {
+        transactionState.activeChart = 'pe';
+        const res = await getActiveChartSummaryText();
+        expect(res).toBe('pe text');
+        expect(peSpy).toHaveBeenCalledWith();
+    });
+
+    it('returns rolling text for rolling', async () => {
+        transactionState.activeChart = 'rolling';
+        const res = await getActiveChartSummaryText();
+        expect(res).toBe('rolling text');
+        expect(rollingSpy).toHaveBeenCalledWith({ includeHidden: true });
+    });
+
+    it('returns volatility text for volatility', async () => {
+        transactionState.activeChart = 'volatility';
+        const res = await getActiveChartSummaryText();
+        expect(res).toBe('volatility text');
+        expect(volatilitySpy).toHaveBeenCalledWith({ includeHidden: true });
+    });
+
+    it('returns yield text for yield', async () => {
+        transactionState.activeChart = 'yield';
+        const res = await getActiveChartSummaryText();
+        expect(res).toBe('yield text');
+        expect(yieldSpy).toHaveBeenCalledWith();
+    });
+
+    it('returns beta text for beta', async () => {
+        transactionState.activeChart = 'beta';
+        const res = await getActiveChartSummaryText();
+        expect(res).toBe('beta text');
+        expect(betaSpy).toHaveBeenCalledWith();
+    });
+
+    it('returns geography text for geography', async () => {
+        transactionState.activeChart = 'geography';
+        const res = await getActiveChartSummaryText();
+        expect(res).toBe('geography text');
+        expect(geographySpy).toHaveBeenCalledWith();
+    });
+
+    it('returns geography text for geographyAbs', async () => {
+        transactionState.activeChart = 'geographyAbs';
+        const res = await getActiveChartSummaryText();
+        expect(res).toBe('geography text');
+        expect(geographySpy).toHaveBeenCalledWith({ labelPrefix: 'Geography Abs' });
+    });
+
+    it('returns marketcap text for marketcap', async () => {
+        transactionState.activeChart = 'marketcap';
+        const res = await getActiveChartSummaryText();
+        expect(res).toBe('marketcap text');
+        expect(marketcapSpy).toHaveBeenCalledWith();
+    });
+
+    it('returns marketcap text for marketcapAbs', async () => {
+        transactionState.activeChart = 'marketcapAbs';
+        const res = await getActiveChartSummaryText();
+        expect(res).toBe('marketcap text');
+        expect(marketcapSpy).toHaveBeenCalledWith({ labelPrefix: 'Market Cap Abs' });
+    });
+
+    it('returns null for unknown charts', async () => {
+        transactionState.activeChart = 'unknown';
+        const res = await getActiveChartSummaryText();
+        expect(res).toBeNull();
     });
 });

--- a/tests/js/transactions/terminal_commands.test.js
+++ b/tests/js/transactions/terminal_commands.test.js
@@ -1,0 +1,184 @@
+import { executeCommand } from '../../../js/transactions/terminal/commands.js';
+import * as helpHandlers from '../../../js/transactions/terminal/handlers/help.js';
+import * as statsHandlers from '../../../js/transactions/terminal/handlers/stats.js';
+import * as plotHandlers from '../../../js/transactions/terminal/handlers/plot.js';
+import * as transactionHandlers from '../../../js/transactions/terminal/handlers/transaction.js';
+import * as miscHandlers from '../../../js/transactions/terminal/handlers/misc.js';
+import * as fadeModule from '../../../js/transactions/fade.js';
+
+// Mock all the imported handlers
+jest.mock('../../../js/transactions/terminal/handlers/help.js');
+jest.mock('../../../js/transactions/terminal/handlers/stats.js');
+jest.mock('../../../js/transactions/terminal/handlers/plot.js');
+jest.mock('../../../js/transactions/terminal/handlers/transaction.js');
+jest.mock('../../../js/transactions/terminal/handlers/misc.js');
+jest.mock('../../../js/transactions/fade.js');
+
+describe('terminal commands', () => {
+    let mockContext;
+    let mockOnCommandExecuted;
+    let mockClearOutput;
+
+    beforeEach(() => {
+        mockOnCommandExecuted = jest.fn();
+        mockClearOutput = jest.fn();
+        mockContext = {
+            onCommandExecuted: mockOnCommandExecuted,
+            clearOutput: mockClearOutput,
+        };
+
+        jest.clearAllMocks();
+    });
+
+    describe('executeCommand', () => {
+        it('should call handleHelpCommand for "h" or "help"', async () => {
+            await executeCommand('help arg1', mockContext);
+            expect(helpHandlers.handleHelpCommand).toHaveBeenCalledWith(['arg1'], expect.objectContaining({ clearOutput: mockClearOutput }));
+
+            await executeCommand('h arg2', mockContext);
+            expect(helpHandlers.handleHelpCommand).toHaveBeenCalledWith(['arg2'], expect.any(Object));
+        });
+
+        it('should call handleStatsCommand for "s" or "stats"', async () => {
+            await executeCommand('stats arg', mockContext);
+            expect(statsHandlers.handleStatsCommand).toHaveBeenCalledWith(['arg'], expect.any(Object));
+
+            await executeCommand('s arg', mockContext);
+            expect(statsHandlers.handleStatsCommand).toHaveBeenCalledWith(['arg'], expect.any(Object));
+        });
+
+        it('should call handlePlotCommand for "p" or "plot"', async () => {
+            await executeCommand('plot arg', mockContext);
+            expect(plotHandlers.handlePlotCommand).toHaveBeenCalledWith(['arg'], expect.any(Object));
+
+            await executeCommand('p arg', mockContext);
+            expect(plotHandlers.handlePlotCommand).toHaveBeenCalledWith(['arg'], expect.any(Object));
+        });
+
+        it('should call handleTransactionCommand for "t" or "transaction"', async () => {
+            await executeCommand('transaction arg', mockContext);
+            expect(transactionHandlers.handleTransactionCommand).toHaveBeenCalledWith(['arg'], expect.any(Object));
+
+            await executeCommand('t arg', mockContext);
+            expect(transactionHandlers.handleTransactionCommand).toHaveBeenCalledWith(['arg'], expect.any(Object));
+        });
+
+        it('should call handleAllCommand for "all"', async () => {
+            await executeCommand('all arg', mockContext);
+            expect(miscHandlers.handleAllCommand).toHaveBeenCalledWith(['arg'], expect.any(Object));
+        });
+
+        it('should call handleAllTimeCommand for "alltime"', async () => {
+            await executeCommand('alltime arg', mockContext);
+            expect(miscHandlers.handleAllTimeCommand).toHaveBeenCalledWith(['arg'], expect.any(Object));
+        });
+
+        it('should call handleAllStockCommand for "allstock"', async () => {
+            await executeCommand('allstock arg', mockContext);
+            expect(miscHandlers.handleAllStockCommand).toHaveBeenCalledWith(['arg'], expect.any(Object));
+        });
+
+        it('should call handleResetCommand for "reset"', async () => {
+            await executeCommand('reset arg', mockContext);
+            expect(miscHandlers.handleResetCommand).toHaveBeenCalledWith(['arg'], expect.any(Object));
+        });
+
+        it('should call handleClearCommand for "clear"', async () => {
+            await executeCommand('clear arg', mockContext);
+            expect(miscHandlers.handleClearCommand).toHaveBeenCalledWith(['arg'], expect.any(Object));
+        });
+
+        it('should call handleZoomCommand for "zoom" or "z"', async () => {
+            await executeCommand('zoom arg', mockContext);
+            expect(miscHandlers.handleZoomCommand).toHaveBeenCalledWith(['arg'], expect.any(Object));
+
+            await executeCommand('z arg', mockContext);
+            expect(miscHandlers.handleZoomCommand).toHaveBeenCalledWith(['arg'], expect.any(Object));
+        });
+
+        it('should call handleLabelCommand for "label" or "l"', async () => {
+            await executeCommand('label arg', mockContext);
+            expect(miscHandlers.handleLabelCommand).toHaveBeenCalledWith(['arg'], expect.any(Object));
+
+            await executeCommand('l arg', mockContext);
+            expect(miscHandlers.handleLabelCommand).toHaveBeenCalledWith(['arg'], expect.any(Object));
+        });
+
+        it('should call handleAbsCommand for "abs", "absolute" or "a"', async () => {
+            await executeCommand('abs arg', mockContext);
+            expect(miscHandlers.handleAbsCommand).toHaveBeenCalledWith(['arg'], expect.any(Object));
+
+            await executeCommand('absolute arg', mockContext);
+            expect(miscHandlers.handleAbsCommand).toHaveBeenCalledWith(['arg'], expect.any(Object));
+
+            await executeCommand('a arg', mockContext);
+            expect(miscHandlers.handleAbsCommand).toHaveBeenCalledWith(['arg'], expect.any(Object));
+        });
+
+        it('should call handlePercentageCommand for "percentage", "percent", or "per"', async () => {
+            await executeCommand('percentage arg', mockContext);
+            expect(miscHandlers.handlePercentageCommand).toHaveBeenCalledWith(['arg'], expect.any(Object));
+
+            await executeCommand('percent arg', mockContext);
+            expect(miscHandlers.handlePercentageCommand).toHaveBeenCalledWith(['arg'], expect.any(Object));
+
+            await executeCommand('per arg', mockContext);
+            expect(miscHandlers.handlePercentageCommand).toHaveBeenCalledWith(['arg'], expect.any(Object));
+        });
+
+        it('should call handleRollingCommand for "rolling"', async () => {
+            await executeCommand('rolling arg', mockContext);
+            expect(miscHandlers.handleRollingCommand).toHaveBeenCalledWith(['arg'], expect.any(Object));
+        });
+
+        it('should call handleCumulativeCommand for "cumulative"', async () => {
+            await executeCommand('cumulative arg', mockContext);
+            expect(miscHandlers.handleCumulativeCommand).toHaveBeenCalledWith(['arg'], expect.any(Object));
+        });
+
+        it('should call handleCompositionCommand for "composition"', async () => {
+            await executeCommand('composition arg', mockContext);
+            expect(miscHandlers.handleCompositionCommand).toHaveBeenCalledWith(['arg'], expect.any(Object));
+        });
+
+        it('should call handleSectorsCommand for "sectors"', async () => {
+            await executeCommand('sectors arg', mockContext);
+            expect(miscHandlers.handleSectorsCommand).toHaveBeenCalledWith(['arg'], expect.any(Object));
+        });
+
+        it('should call handleGeographyCommand for "geography"', async () => {
+            await executeCommand('geography arg', mockContext);
+            expect(miscHandlers.handleGeographyCommand).toHaveBeenCalledWith(['arg'], expect.any(Object));
+        });
+
+        it('should call handleMarketcapCommand for "marketcap"', async () => {
+            await executeCommand('marketcap arg', mockContext);
+            expect(miscHandlers.handleMarketcapCommand).toHaveBeenCalledWith(['arg'], expect.any(Object));
+        });
+
+        it('should call handleSummaryCommand for "summary"', async () => {
+            await executeCommand('summary arg', mockContext);
+            expect(miscHandlers.handleSummaryCommand).toHaveBeenCalledWith(['arg'], expect.any(Object));
+        });
+
+        it('should call handleDefaultCommand for unknown commands', async () => {
+            await executeCommand('unknown arg', mockContext);
+            expect(transactionHandlers.handleDefaultCommand).toHaveBeenCalledWith('unknown arg', expect.any(Object));
+        });
+
+        it('should set fade preserve second last to false', async () => {
+            await executeCommand('help', mockContext);
+            expect(fadeModule.setFadePreserveSecondLast).toHaveBeenCalledWith(false);
+        });
+
+        it('should call onCommandExecuted if it is a function', async () => {
+            await executeCommand('help', mockContext);
+            expect(mockOnCommandExecuted).toHaveBeenCalledTimes(1);
+        });
+
+        it('should not throw if onCommandExecuted is missing', async () => {
+            await expect(executeCommand('help', {})).resolves.not.toThrow();
+        });
+    });
+
+});


### PR DESCRIPTION
- What: Added robust unit tests for `executeCommand`, `ensureTransactionTableVisible`/`isTransactionTableVisible`, and `getActiveChartSummaryText` in the terminal module.
- Why: To fulfill the TestPilot mission of adding missing coverage to 3 utility areas, improving the resilience of the terminal logic.
- Impact: Increased statement and branch coverage in `commands.js` and `viewUtils.js`, ensuring that UI state toggles and command dispatching behave predictably.
- Measurement: Test suite passes locally, and Jest coverage reports indicate increased coverage for the targeted files.

---
*PR created automatically by Jules for task [6127417482526214028](https://jules.google.com/task/6127417482526214028) started by @ryusoh*