### PR TITLE
Palette: Add explicit visual empty state for terminal charts

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -79,3 +79,9 @@
 
 **Learning:** Adding `tabindex="0"` to non-interactive structural or layout containers (like `.left-col` or `.right-col`) to make them scrollable is an accessibility anti-pattern. It creates confusing stops for screen reader users on elements that have no interactive purpose or semantic meaning.
 **Action:** Do not add `tabindex="0"` to non-interactive structural or layout layout containers. Let the user scroll naturally without forcing focus onto the layout structure itself.
+
+## 2026-04-26 - Visual Empty States for Canvas Charts
+
+**Learning:** When using canvas-based data visualizations, an empty canvas without an explicit visual empty state overlay makes the application appear broken or stuck loading when there is genuinely no data to display. Relying solely on `display: none` for the canvas itself often breaks grid/flexbox layouts.
+
+**Action:** Always provide an explicit visual empty state overlay (e.g., `.chart-empty` with an icon and clear message) over the chart container when no data is available to clearly communicate the state to the user.

--- a/css/terminal/chart.css
+++ b/css/terminal/chart.css
@@ -147,3 +147,33 @@
     border: none;
     align-self: center;
 }
+
+.chart-empty {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 10;
+    background: rgba(17, 17, 17, 0.7);
+    -webkit-backdrop-filter: blur(4px);
+    backdrop-filter: blur(4px);
+    border-radius: 12px;
+}
+
+.chart-empty-content {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+    color: #8b949e;
+    font-size: 14px;
+}
+
+.chart-empty-content i {
+    font-size: 32px;
+    margin-bottom: 12px;
+    opacity: 0.5;
+}

--- a/terminal/index.html
+++ b/terminal/index.html
@@ -166,7 +166,12 @@
                         role="img"
                         aria-label="Running amount chart"
                     ></canvas>
-                    <div class="chart-empty" id="runningAmountEmpty" style="display: none"></div>
+                    <div class="chart-empty" id="runningAmountEmpty" style="display: none">
+                        <div class="chart-empty-content">
+                            <i class="fa fa-line-chart" aria-hidden="true"></i>
+                            <p>No data available in this range</p>
+                        </div>
+                    </div>
                 </div>
                 <div class="chart-legend"></div>
             </section>


### PR DESCRIPTION
💡 What: Added a visual empty state overlay for terminal charts when no data is available in the selected range.
🎯 Why: Prevents users from assuming the application is broken or stuck loading when there is genuinely no data to display.
📸 Before/After: Visual change added to terminal charts.
♿ Accessibility: Improved feedback for state changes.

---
*PR created automatically by Jules for task [2560631545216551234](https://jules.google.com/task/2560631545216551234) started by @ryusoh*