### PR TITLE
⚡ Bolt: Optimize fade update array allocations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -157,3 +157,8 @@
 
 **Learning:** Chaining `.map().filter().map()` inside `performance.js` and other chart renderers creates multiple intermediate short-lived arrays. In tight rendering loops or on large data structures, this leads to significant array allocation overhead, max call stack limits, and garbage collection (GC) pressure.
 **Action:** Replaced chained higher-order array methods with a single inline manual `for` loop. Iterate over the input array, check the condition, compute the mapped values, and push directly to a newly instantiated single output array. This reduces execution time and prevents unnecessary GC pauses.
+
+## 2026-05-02 - Replaced Array.from().forEach() with standard loops
+
+**Learning:** Using `Array.from(nodeList).forEach()` inside high-frequency paths like event listeners or UI update functions creates implicit closures and unnecessary intermediate array allocations, increasing garbage collection (GC) pressure and reducing frontend responsiveness.
+**Action:** Replace `Array.from(nodeList).forEach()` with standard index-based `for` loops (`for (let i = 0; i < nodeList.length; i++)`) to prevent intermediate array creation and closure allocations, leading to smoother animations and scroll experiences.

--- a/js/transactions/fade.js
+++ b/js/transactions/fade.js
@@ -14,11 +14,12 @@ export function setFadePreserveSecondLast(preserve) {
 function updateOutputFade(outputContainer) {
     const isMobile = window.innerWidth <= 768;
     if (isMobile) {
-        Array.from(outputContainer.children).forEach((child) => {
+        for (let i = 0; i < outputContainer.children.length; i++) {
+            const child = outputContainer.children[i];
             if (child && child.nodeType === 1) {
                 child.style.opacity = '1';
             }
-        });
+        }
         return;
     }
 
@@ -34,22 +35,23 @@ function updateOutputFade(outputContainer) {
     const secondLastChild = lastChild ? lastChild.previousElementSibling : null;
     const thirdLastChild = secondLastChild ? secondLastChild.previousElementSibling : null;
 
-    Array.from(outputContainer.children).forEach((child) => {
+    for (let i = 0; i < outputContainer.children.length; i++) {
+        const child = outputContainer.children[i];
         if (!child || child.nodeType !== 1) {
-            return;
+            continue;
         }
 
         // Constraint: Never fade the most recent output
         if (child === lastChild) {
             child.style.opacity = '1';
-            return;
+            continue;
         }
 
         // Constraint: If preserved, keep context (last 3 items) opaque
         // This covers: Zoom Prompt (2nd last) and Previous Output (3rd last)
         if (preserveSecondLast && (child === secondLastChild || child === thirdLastChild)) {
             child.style.opacity = '1';
-            return;
+            continue;
         }
 
         if (!child.style.transition) {
@@ -61,12 +63,12 @@ function updateOutputFade(outputContainer) {
 
         if (relativeBottom <= 0) {
             child.style.opacity = '0';
-            return;
+            continue;
         }
 
         if (relativeTop >= threshold) {
             child.style.opacity = '';
-            return;
+            continue;
         }
 
         const visibleTop = Math.max(relativeTop, 0);
@@ -78,7 +80,7 @@ function updateOutputFade(outputContainer) {
         );
         const opacity = MIN_FADE_OPACITY + (1 - MIN_FADE_OPACITY) * coverage;
         child.style.opacity = opacity.toFixed(2);
-    });
+    }
 }
 
 /**


### PR DESCRIPTION
💡 What: Replaced `Array.from(outputContainer.children).forEach()` with index-based `for` loops in the high-frequency `updateOutputFade` scroll handler.
🎯 Why: Using `Array.from().forEach()` inside scroll event handlers creates implicit closures and unnecessary intermediate array allocations, increasing garbage collection (GC) pressure and risking dropped frames.
📊 Impact: Eliminates O(N) intermediate array allocations and closure creation per scroll frame, leading to smoother scrolling performance and reduced memory overhead.
🔬 Measurement: Profile the memory allocation and call stack during terminal scrolling to observe zero intermediate arrays created by the fade update loop.

---
*PR created automatically by Jules for task [15034524358317246578](https://jules.google.com/task/15034524358317246578) started by @ryusoh*