### PR TITLE
Bolt: Optimize computeWeightedMedian by removing map/filter/reduce chain

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -165,3 +165,7 @@
 ## 2026-05-03 - Replaced Array.map().slice() with standard for-loop inside High-Frequency Event Handler
 **Learning:** Using chained `.map()` and `.slice()` in `js/transactions/chart/interaction.js` inside high-frequency mouse event handlers (like crosshairs) triggers large intermediate array allocations leading to GC overhead and stutters.
 **Action:** Replace `.map()` with pre-sized `new Array()` and index-based `for` loops. Also replace `.slice()` and array `forEach()` closures with direct element access loops to keep allocations completely stable (O(1)) during chart interaction loops.
+
+## 2026-05-05 - Replaced .map().filter().reduce() chains in computeWeightedMedian
+**Learning:** Chaining `.map().filter().reduce()` when processing collections (like in statistical functions computing medians) allocates multiple intermediate arrays and processes the data across multiple O(N) passes, increasing Garbage Collection overhead.
+**Action:** Replaced chained array methods with a single manual `for` loop that computes weights and values, filters valid items, tracks the total sum inline, and directly populates the final array, keeping the operation O(N) with minimal GC pressure.

--- a/js/transactions/terminal/stats/analysis.js
+++ b/js/transactions/terminal/stats/analysis.js
@@ -29,22 +29,24 @@ function normalizeTickerKey(ticker) {
 }
 
 function computeWeightedMedian(entries, weightGetter, valueGetter) {
-    const normalized = entries
-        .map((entry) => {
-            const weight = weightGetter(entry);
-            const value = valueGetter(entry);
-            if (!Number.isFinite(weight) || weight <= 0 || !Number.isFinite(value)) {
-                return null;
-            }
-            return { weight, value };
-        })
-        .filter(Boolean)
-        .sort((a, b) => a.value - b.value);
+    const normalized = [];
+    let totalWeight = 0;
+    for (let i = 0; i < entries.length; i += 1) {
+        const entry = entries[i];
+        const weight = weightGetter(entry);
+        const value = valueGetter(entry);
+        if (Number.isFinite(weight) && weight > 0 && Number.isFinite(value)) {
+            normalized.push({ weight, value });
+            totalWeight += weight;
+        }
+    }
 
-    const totalWeight = normalized.reduce((sum, item) => sum + item.weight, 0);
     if (totalWeight <= 0) {
         return null;
     }
+
+    normalized.sort((a, b) => a.value - b.value);
+
     let cumulative = 0;
     for (let i = 0; i < normalized.length; i += 1) {
         cumulative += normalized[i].weight;


### PR DESCRIPTION
**What**: Replaced the `.map().filter().reduce()` chain in `computeWeightedMedian` with a single manual `for` loop that simultaneously filters, constructs the normalized objects, and calculates the `totalWeight`.
**Why**: The original implementation allocated two intermediate arrays (one padded with `null`s during map and a filtered array) and traversed the collection multiple times, adding unnecessary closure and Garbage Collection overhead.
**Impact**: Eliminates intermediate array allocations and reduces function execution to a single pass before sorting, improving memory usage and reducing GC pressure on recalculations.
**Measurement**: Execution time and GC pauses inside analysis statistics recalculations should be lower. Verify standard tests still pass perfectly to guarantee correct median calculations.

---
*PR created automatically by Jules for task [9614746955902475707](https://jules.google.com/task/9614746955902475707) started by @ryusoh*