### PR TITLE
test: add coverage for rolling, marketcap, and geography chart renderers

### DIFF
--- a/.jules/testpilot.md
+++ b/.jules/testpilot.md
@@ -49,4 +49,8 @@ What: Added test coverage to `js/transactions/terminalStats.js`, `js/ui/marquee.
 Coverage: Brought `terminalStats.js`, `marquee.js`, `tableGlassEffect.js`, and `monte_carlo.worker.js` closer to 100% and increased `nav_prefetch.js` coverage significantly. Used a dummy coverage export for `terminalStats.js`, mocked DOM geometry for `marquee.js`, evaluated worker code in a mocked `self` environment, and used mock injections for `navigator.connection`.
 Result: Met the daily goal of multiple targets, expanding coverage without modifying production logic. Ran full test suite to ensure no regressions.
 
-## 2024-05-24\n\nWhat: Added test coverage to `js/transactions/chart/renderers/rolling.js`, `marketcap.js`, and `geography.js`.\nCoverage: Brought missing renderers closer to 100% by targeting empty state early exits using Jest.\nResult: Tested and verified gracefull exits for zero data/series, increasing system resilience and satisfying test targets without modifying production code.
+## 2024-05-24
+
+What: Added test coverage to `js/transactions/chart/renderers/rolling.js`, `marketcap.js`, and `geography.js`.
+Coverage: Brought missing renderers closer to 100% by targeting empty state early exits using Jest.
+Result: Tested and verified gracefull exits for zero data/series, increasing system resilience and satisfying test targets without modifying production code.

--- a/.jules/testpilot.md
+++ b/.jules/testpilot.md
@@ -48,3 +48,5 @@ Result: Targeted `js/transactions/table` component directory which had significa
 What: Added test coverage to `js/transactions/terminalStats.js`, `js/ui/marquee.js`, `js/pages/analysis/monte_carlo.worker.js`, `js/ui/nav_prefetch.js`, and `js/ui/tableGlassEffect.js`.
 Coverage: Brought `terminalStats.js`, `marquee.js`, `tableGlassEffect.js`, and `monte_carlo.worker.js` closer to 100% and increased `nav_prefetch.js` coverage significantly. Used a dummy coverage export for `terminalStats.js`, mocked DOM geometry for `marquee.js`, evaluated worker code in a mocked `self` environment, and used mock injections for `navigator.connection`.
 Result: Met the daily goal of multiple targets, expanding coverage without modifying production logic. Ran full test suite to ensure no regressions.
+
+## 2024-05-24\n\nWhat: Added test coverage to `js/transactions/chart/renderers/rolling.js`, `marketcap.js`, and `geography.js`.\nCoverage: Brought missing renderers closer to 100% by targeting empty state early exits using Jest.\nResult: Tested and verified gracefull exits for zero data/series, increasing system resilience and satisfying test targets without modifying production code.

--- a/tests/js/transactions/chart/renderers/geography.test.js
+++ b/tests/js/transactions/chart/renderers/geography.test.js
@@ -1,0 +1,42 @@
+import {
+    drawGeographyChart,
+    drawGeographyAbsoluteChart,
+} from '@js/transactions/chart/renderers/geography.js';
+
+jest.mock('@js/transactions/state.js', () => ({
+    transactionState: {},
+}));
+jest.mock('@js/transactions/chart/state.js', () => ({
+    chartLayouts: {},
+}));
+jest.mock('@js/transactions/chart/interaction.js', () => ({
+    updateCrosshairUI: jest.fn(),
+    updateLegend: jest.fn(),
+    drawCrosshairOverlay: jest.fn(),
+}));
+jest.mock('@js/transactions/chart/animation.js', () => ({
+    stopPerformanceAnimation: jest.fn(),
+    stopContributionAnimation: jest.fn(),
+    stopFxAnimation: jest.fn(),
+}));
+jest.mock('@js/transactions/dataLoader.js', () => ({
+    loadGeographySnapshotData: jest.fn().mockResolvedValue(null),
+}));
+jest.mock('@js/utils/logger.js', () => ({
+    logger: { warn: jest.fn() },
+}));
+
+describe('Geography Chart Renderer', () => {
+    it('handles empty initialization safely', () => {
+        document.body.innerHTML = '<div id="runningAmountEmpty"></div>';
+        const ctx = {};
+        const chartManager = {};
+
+        drawGeographyChart(ctx, chartManager);
+        drawGeographyAbsoluteChart(ctx, chartManager);
+
+        return new Promise(process.nextTick).then(() => {
+            expect(document.getElementById('runningAmountEmpty').style.display).toBe('block');
+        });
+    });
+});

--- a/tests/js/transactions/chart/renderers/marketcap.test.js
+++ b/tests/js/transactions/chart/renderers/marketcap.test.js
@@ -1,0 +1,42 @@
+import {
+    drawMarketcapChart,
+    drawMarketcapAbsoluteChart,
+} from '@js/transactions/chart/renderers/marketcap.js';
+
+jest.mock('@js/transactions/state.js', () => ({
+    transactionState: {},
+}));
+jest.mock('@js/transactions/chart/state.js', () => ({
+    chartLayouts: {},
+}));
+jest.mock('@js/transactions/chart/interaction.js', () => ({
+    updateCrosshairUI: jest.fn(),
+    updateLegend: jest.fn(),
+    drawCrosshairOverlay: jest.fn(),
+}));
+jest.mock('@js/transactions/chart/animation.js', () => ({
+    stopPerformanceAnimation: jest.fn(),
+    stopContributionAnimation: jest.fn(),
+    stopFxAnimation: jest.fn(),
+}));
+jest.mock('@js/transactions/dataLoader.js', () => ({
+    loadMarketcapSnapshotData: jest.fn().mockResolvedValue(null),
+}));
+jest.mock('@js/utils/logger.js', () => ({
+    logger: { warn: jest.fn() },
+}));
+
+describe('Marketcap Chart Renderer', () => {
+    it('handles empty initialization safely', () => {
+        document.body.innerHTML = '<div id="runningAmountEmpty"></div>';
+        const ctx = {};
+        const chartManager = {};
+
+        drawMarketcapChart(ctx, chartManager);
+        drawMarketcapAbsoluteChart(ctx, chartManager);
+
+        return new Promise(process.nextTick).then(() => {
+            expect(document.getElementById('runningAmountEmpty').style.display).toBe('block');
+        });
+    });
+});

--- a/tests/js/transactions/chart/renderers/rolling.test.js
+++ b/tests/js/transactions/chart/renderers/rolling.test.js
@@ -1,0 +1,36 @@
+import { drawRollingChart } from '@js/transactions/chart/renderers/rolling.js';
+import { transactionState } from '@js/transactions/state.js';
+import { chartLayouts } from '@js/transactions/chart/state.js';
+
+jest.mock('@js/transactions/state.js', () => ({
+    transactionState: {
+        performanceSeries: {},
+        selectedCurrency: 'USD',
+        chartVisibility: {},
+    },
+    getShowChartLabels: jest.fn(),
+}));
+jest.mock('@js/transactions/chart/state.js', () => ({
+    chartLayouts: {},
+}));
+jest.mock('@js/transactions/chart/interaction.js', () => ({
+    updateCrosshairUI: jest.fn(),
+}));
+jest.mock('@js/transactions/chart/animation.js', () => ({
+    stopPerformanceAnimation: jest.fn(),
+    stopContributionAnimation: jest.fn(),
+    stopFxAnimation: jest.fn(),
+}));
+jest.mock('@js/utils/smoothing.js', () => ({
+    smoothFinancialData: jest.fn(),
+}));
+
+describe('Rolling Chart Renderer', () => {
+    it('handles empty performanceSeries', async () => {
+        const ctx = {};
+        const chartManager = {};
+        transactionState.performanceSeries = {};
+        await drawRollingChart(ctx, chartManager, 0);
+        expect(chartLayouts.rolling).toBeNull();
+    });
+});


### PR DESCRIPTION
What: Added missing Jest test suites for `rolling.js`, `marketcap.js`, and `geography.js` chart renderers.
Why: These files had 0% or ~1% coverage, representing significant gaps in verifying the rendering pipelines.
Impact: Increased test coverage and confidence in chart rendering edge cases.
Measurement: Evaluated via `pnpm test --coverage` confirming increased coverage metrics.

---
*PR created automatically by Jules for task [14981765229524215611](https://jules.google.com/task/14981765229524215611) started by @ryusoh*