### PR TITLE
Bolt: Optimize series array mapping and reduce closure overhead

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -169,3 +169,7 @@
 ## 2026-05-05 - Replaced .map().filter().reduce() chains in computeWeightedMedian
 **Learning:** Chaining `.map().filter().reduce()` when processing collections (like in statistical functions computing medians) allocates multiple intermediate arrays and processes the data across multiple O(N) passes, increasing Garbage Collection overhead.
 **Action:** Replaced chained array methods with a single manual `for` loop that computes weights and values, filters valid items, tracks the total sum inline, and directly populates the final array, keeping the operation O(N) with minimal GC pressure.
+
+## 2025-05-06 - Array.prototype.map Optimization in Terminal Series Iteration
+**Learning:** High-frequency `.map` operations that also include `.some()` scans to check for properties cause multiple full-array iterations and excessive object closure allocations per data point, increasing garbage collection pressure.
+**Action:** Replace `.some()` and `.map()` with a combined traditional `for` loop, pre-allocate arrays (`new Array(len)`), and retain explicit spreading (`{...item}`) to safely preserve properties while minimizing loop overhead.

--- a/js/pages/terminal/index.js
+++ b/js/pages/terminal/index.js
@@ -32,13 +32,21 @@ function convertCurrencySeries(series, targetCurrency) {
         return series;
     }
 
-    const hasNetAmount = series.some((entry) =>
-        Object.prototype.hasOwnProperty.call(entry, 'netAmount')
-    );
+    const len = series.length;
+    let hasNetAmount = false;
+    for (let i = 0; i < len; i += 1) {
+        if (Object.prototype.hasOwnProperty.call(series[i], 'netAmount')) {
+            hasNetAmount = true;
+            break;
+        }
+    }
+
+    const resultSeries = new Array(len);
 
     if (hasNetAmount) {
         let cumulative = 0;
-        return series.map((item) => {
+        for (let i = 0; i < len; i += 1) {
+            const item = series[i];
             const dateRef = item.tradeDate || item.date;
             const convertedNet = convertValueToCurrency(item.netAmount, dateRef, targetCurrency);
             cumulative += convertedNet;
@@ -49,17 +57,20 @@ function convertCurrencySeries(series, targetCurrency) {
             if (item.synthetic && item.orderType === 'padding') {
                 result.amount = cumulative;
             }
-            return result;
-        });
+            resultSeries[i] = result;
+        }
+        return resultSeries;
     }
 
-    return series.map((item) => {
+    for (let i = 0; i < len; i += 1) {
+        const item = series[i];
         const result = { ...item };
         if ('value' in item) {
             result.value = convertValueToCurrency(item.value, item.date, targetCurrency);
         }
-        return result;
-    });
+        resultSeries[i] = result;
+    }
+    return resultSeries;
 }
 import {
     loadSplitHistory,


### PR DESCRIPTION
What: Replaced .some() and .map() calls in convertCurrencySeries with pre-allocated arrays and standard for-loops.
Why: High-frequency array mapping and scanning in tight loops results in multiple full array iterations and excessive temporary closure objects.
Impact: Reduces intermediate allocations and garbage collection pressure when converting series data points, resulting in faster terminal rendering for large datasets.
Measurement: Profile the 'convertCurrencySeries' execution time in the terminal data flow before and after.

---
*PR created automatically by Jules for task [8820535328794705137](https://jules.google.com/task/8820535328794705137) started by @ryusoh*