### PR TITLE
Palette: Fix missing aria-pressed sync in currency bootstrap

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -79,3 +79,5 @@
 
 **Learning:** Adding `tabindex="0"` to non-interactive structural or layout containers (like `.left-col` or `.right-col`) to make them scrollable is an accessibility anti-pattern. It creates confusing stops for screen reader users on elements that have no interactive purpose or semantic meaning.
 **Action:** Do not add `tabindex="0"` to non-interactive structural or layout layout containers. Let the user scroll naturally without forcing focus onto the layout structure itself.
+
+## 2026-05-08 - Accessible Toggle Bootstrap\n\n**Learning:** During page load bootstrap scripts that restore UI toggle states (like currency toggles) without a framework, the initialization script often updates the visual CSS class (`active`) but forgets to sync the corresponding ARIA attribute (`aria-pressed`). This creates a mismatch for screen readers, announcing an incorrect state on initial load.\n\n**Action:** Always ensure that bootstrap scripts that manually modify `.active` CSS classes on toggles also explicitly update the `aria-pressed` attribute to maintain accessibility parity.\n

--- a/js/ui/currencyBootstrap.js
+++ b/js/ui/currencyBootstrap.js
@@ -27,9 +27,11 @@ function bootstrapStoredCurrency() {
                     target = button;
                 }
                 button.classList.remove('active');
+                button.setAttribute('aria-pressed', 'false');
             });
             if (target) {
                 target.classList.add('active');
+                target.setAttribute('aria-pressed', 'true');
             }
         });
     } catch (error) {

--- a/tests/js/ui/currencyBootstrap.test.js
+++ b/tests/js/ui/currencyBootstrap.test.js
@@ -44,13 +44,13 @@ describe('currencyBootstrap', () => {
         expect(document.documentElement.getAttribute('data-selected-currency')).toBe('GBP');
     });
 
-    test('updates currency toggle buttons active state', () => {
+    test('updates currency toggle buttons active state and aria-pressed attributes', () => {
         window.localStorage.setItem('fund.selectedCurrency', 'EUR');
 
         document.body.innerHTML = `
             <div id="currencyToggleContainer">
-                <button class="currency-toggle active" data-currency="USD">USD</button>
-                <button class="currency-toggle" data-currency="EUR">EUR</button>
+                <button class="currency-toggle active" aria-pressed="true" data-currency="USD">USD</button>
+                <button class="currency-toggle" aria-pressed="false" data-currency="EUR">EUR</button>
             </div>
         `;
 
@@ -60,7 +60,9 @@ describe('currencyBootstrap', () => {
         const eurButton = document.querySelector('[data-currency="EUR"]');
 
         expect(usdButton.classList.contains('active')).toBe(false);
+        expect(usdButton.getAttribute('aria-pressed')).toBe('false');
         expect(eurButton.classList.contains('active')).toBe(true);
+        expect(eurButton.getAttribute('aria-pressed')).toBe('true');
     });
 
     test('handles missing matching target gracefully', () => {


### PR DESCRIPTION
What: Updated bootstrapStoredCurrency to synchronize the aria-pressed attribute when manually setting the .active class on currency toggle buttons on initial page load. Updated the corresponding tests.

Why: During page load, the bootstrap script restores the user's selected currency from local storage and adds the `.active` CSS class. However, it neglected to update the `aria-pressed` attribute, causing screen readers to incorrectly announce the buttons' state when users first navigated to them.

Accessibility: Ensures that currency toggles correctly announce their true toggled state to assistive technologies immediately upon page load.

---
*PR created automatically by Jules for task [8854516243388891599](https://jules.google.com/task/8854516243388891599) started by @ryusoh*