### PR TITLE
⚡ Bolt: Optimize applyDrawdownToSeries to use pre-allocated arrays

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -173,3 +173,6 @@
 ## 2025-05-06 - Array.prototype.map Optimization in Terminal Series Iteration
 **Learning:** High-frequency `.map` operations that also include `.some()` scans to check for properties cause multiple full-array iterations and excessive object closure allocations per data point, increasing garbage collection pressure.
 **Action:** Replace `.some()` and `.map()` with a combined traditional `for` loop, pre-allocate arrays (`new Array(len)`), and retain explicit spreading (`{...item}`) to safely preserve properties while minimizing loop overhead.
+## 2026-05-09 - Pre-allocating Map Arrays for Drawdowns
+**Learning:** When iterating through sorted arrays to compute drawdowns, using `.map()` dynamically grows the array and creates implicit closures, adding pressure on Garbage Collection.
+**Action:** Replaced `.map()` in `applyDrawdownToSeries` with a pre-allocated array (`new Array(len)`) and a standard `for` loop to eliminate intermediate allocations and ensure O(1) space growth per iteration.

--- a/js/transactions/chart/data/contribution.js
+++ b/js/transactions/chart/data/contribution.js
@@ -416,16 +416,21 @@ export function applyDrawdownToSeries(data, valueKey, initialPeak = -Infinity) {
     // Sort by date first
     const sorted = [...data].sort((a, b) => (a.date < b.date ? -1 : a.date > b.date ? 1 : 0));
     let runningPeak = initialPeak;
-    return sorted.map((p) => {
+    const len = sorted.length;
+    // Bolt: Use pre-allocated Array and a standard loop instead of .map() to avoid closure allocations and eliminate array growth overhead.
+    const result = new Array(len);
+    for (let i = 0; i < len; i++) {
+        const p = sorted[i];
         const val = p[valueKey];
         if (val > runningPeak) {
             runningPeak = val;
         }
-        return {
+        result[i] = {
             ...p,
             [valueKey]: val - runningPeak, // <= 0
         };
-    });
+    }
+    return result;
 }
 
 /**


### PR DESCRIPTION
💡 What: Replaced `.map()` with a pre-allocated array and standard `for` loop in `applyDrawdownToSeries` (with an inline comment explaining the optimization).
🎯 Why: To eliminate dynamic array growth and implicit closure overhead, which adds Garbage Collection pressure.
📊 Impact: Reduces memory allocation overhead and minimizes GC pauses during chart redraws.
🔬 Measurement: Check memory allocations using the performance panel during timeframe/filter toggles.

---
*PR created automatically by Jules for task [13371883086270818200](https://jules.google.com/task/13371883086270818200) started by @ryusoh*