### PR TITLE
test: Add unit test coverage for missing chart renderers

### DIFF
--- a/tests/js/transactions/chart/renderers/performance.test.js
+++ b/tests/js/transactions/chart/renderers/performance.test.js
@@ -1,0 +1,42 @@
+import { drawPerformanceChart } from '@js/transactions/chart/renderers/performance.js';
+import { transactionState } from '@js/transactions/state.js';
+import { chartLayouts } from '@js/transactions/chart/state.js';
+
+jest.mock('@js/transactions/state.js', () => ({
+    transactionState: {
+        performanceSeries: {},
+        selectedCurrency: 'USD',
+        chartVisibility: {},
+    },
+    getShowChartLabels: jest.fn(),
+    legendState: { performanceDirty: false },
+}));
+jest.mock('@js/transactions/chart/state.js', () => ({
+    chartLayouts: {},
+}));
+jest.mock('@js/transactions/chart/interaction.js', () => ({
+    updateCrosshairUI: jest.fn(),
+    drawCrosshairOverlay: jest.fn(),
+    updateLegend: jest.fn(),
+}));
+jest.mock('@js/transactions/chart/animation.js', () => ({
+    stopPerformanceAnimation: jest.fn(),
+    stopContributionAnimation: jest.fn(),
+    stopFxAnimation: jest.fn(),
+    isAnimationEnabled: jest.fn(() => false),
+    advancePerformanceAnimation: jest.fn(() => 1),
+    schedulePerformanceAnimation: jest.fn(),
+}));
+jest.mock('@js/transactions/chart/core.js', () => ({
+    drawAxes: jest.fn(),
+}));
+
+describe('Performance Chart Renderer', () => {
+    it('handles empty performanceSeries gracefully', async () => {
+        const ctx = {};
+        const chartManager = {};
+        transactionState.performanceSeries = {};
+        await drawPerformanceChart(ctx, chartManager, 0);
+        expect(chartLayouts.performance).toBeNull();
+    });
+});

--- a/tests/js/transactions/chart/renderers/sectors.test.js
+++ b/tests/js/transactions/chart/renderers/sectors.test.js
@@ -1,0 +1,48 @@
+import { drawSectorsChart } from '@js/transactions/chart/renderers/sectors.js';
+import { transactionState } from '@js/transactions/state.js';
+import { chartLayouts } from '@js/transactions/chart/state.js';
+import { loadSectorsSnapshotData } from '@js/transactions/dataLoader.js';
+
+jest.mock('@js/transactions/state.js', () => ({
+    transactionState: {
+        performanceSeries: {},
+        selectedCurrency: 'USD',
+        chartVisibility: {},
+    },
+    getShowChartLabels: jest.fn(),
+}));
+jest.mock('@js/transactions/chart/state.js', () => ({
+    chartLayouts: {},
+}));
+jest.mock('@js/transactions/dataLoader.js', () => ({
+    loadSectorsSnapshotData: jest.fn(() => Promise.resolve({})),
+}));
+jest.mock('@js/transactions/chart/interaction.js', () => ({
+    updateCrosshairUI: jest.fn(),
+    drawCrosshairOverlay: jest.fn(),
+}));
+jest.mock('@js/transactions/chart/animation.js', () => ({
+    stopSectorsAnimation: jest.fn(),
+    stopPerformanceAnimation: jest.fn(),
+    stopContributionAnimation: jest.fn(),
+    stopFxAnimation: jest.fn(),
+}));
+jest.mock('@js/utils/smoothing.js', () => ({
+    smoothFinancialData: jest.fn(),
+}));
+jest.mock('@js/transactions/chart/core.js', () => ({
+    drawAxes: jest.fn(),
+}));
+
+describe('Sectors Chart Renderer', () => {
+    it('handles empty data gracefully by showing empty state', async () => {
+        document.body.innerHTML = '<div id="runningAmountEmpty"></div>';
+        const ctx = {};
+        const chartManager = {};
+
+        await drawSectorsChart(ctx, chartManager, 0);
+
+        expect(loadSectorsSnapshotData).toHaveBeenCalled();
+        expect(chartLayouts.sectors).toBeNull();
+    });
+});

--- a/tests/js/transactions/chart/renderers/sectors.test.js
+++ b/tests/js/transactions/chart/renderers/sectors.test.js
@@ -1,5 +1,4 @@
 import { drawSectorsChart } from '@js/transactions/chart/renderers/sectors.js';
-import { transactionState } from '@js/transactions/state.js';
 import { chartLayouts } from '@js/transactions/chart/state.js';
 import { loadSectorsSnapshotData } from '@js/transactions/dataLoader.js';
 

--- a/tests/js/transactions/chart/renderers/yield.test.js
+++ b/tests/js/transactions/chart/renderers/yield.test.js
@@ -1,7 +1,4 @@
 import { drawYieldChart } from '@js/transactions/chart/renderers/yield.js';
-import { transactionState } from '@js/transactions/state.js';
-import { chartLayouts } from '@js/transactions/chart/state.js';
-import { loadYieldData } from '@js/transactions/dataLoader.js';
 
 jest.mock('@js/transactions/state.js', () => ({
     transactionState: {
@@ -46,7 +43,7 @@ describe('Yield Chart Renderer', () => {
     it('handles empty fetch gracefully by updating chartManager', async () => {
         document.body.innerHTML = '<div id="runningAmountEmpty"></div>';
         const ctx = {
-            canvas: { offsetWidth: 800, offsetHeight: 600 }
+            canvas: { offsetWidth: 800, offsetHeight: 600 },
         };
         const chartManager = { update: jest.fn() };
 

--- a/tests/js/transactions/chart/renderers/yield.test.js
+++ b/tests/js/transactions/chart/renderers/yield.test.js
@@ -1,0 +1,64 @@
+import { drawYieldChart } from '@js/transactions/chart/renderers/yield.js';
+import { transactionState } from '@js/transactions/state.js';
+import { chartLayouts } from '@js/transactions/chart/state.js';
+import { loadYieldData } from '@js/transactions/dataLoader.js';
+
+jest.mock('@js/transactions/state.js', () => ({
+    transactionState: {
+        performanceSeries: {},
+        selectedCurrency: 'USD',
+        chartVisibility: {},
+    },
+    getShowChartLabels: jest.fn(),
+    legendState: { yieldDirty: false },
+}));
+jest.mock('@js/transactions/chart/state.js', () => ({
+    chartLayouts: {},
+}));
+jest.mock('@js/transactions/dataLoader.js', () => ({
+    loadYieldData: jest.fn(() => Promise.resolve({ series: [], xLabels: [] })),
+}));
+jest.mock('@js/transactions/chart/interaction.js', () => ({
+    updateCrosshairUI: jest.fn(),
+    drawCrosshairOverlay: jest.fn(),
+    updateLegend: jest.fn(),
+}));
+jest.mock('@js/transactions/chart/animation.js', () => ({
+    stopPeAnimation: jest.fn(),
+    stopConcentrationAnimation: jest.fn(),
+    stopYieldAnimation: jest.fn(),
+    stopPerformanceAnimation: jest.fn(),
+    stopContributionAnimation: jest.fn(),
+    stopFxAnimation: jest.fn(),
+    isAnimationEnabled: jest.fn(() => false),
+    advancePerformanceAnimation: jest.fn(() => 1),
+    schedulePerformanceAnimation: jest.fn(),
+}));
+jest.mock('@js/transactions/chart/core.js', () => ({
+    drawAxes: jest.fn(),
+}));
+
+describe('Yield Chart Renderer', () => {
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('handles empty fetch gracefully by updating chartManager', async () => {
+        document.body.innerHTML = '<div id="runningAmountEmpty"></div>';
+        const ctx = {
+            canvas: { offsetWidth: 800, offsetHeight: 600 }
+        };
+        const chartManager = { update: jest.fn() };
+
+        global.fetch = jest.fn(() =>
+            Promise.resolve({
+                ok: false,
+            })
+        );
+
+        await drawYieldChart(ctx, chartManager, 0);
+        expect(global.fetch).toHaveBeenCalled();
+        await new Promise(process.nextTick);
+        expect(chartManager.update).toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
What:
Added unit tests for three chart renderers: sectors, performance, and yield.

Why:
These renderers previously lacked coverage for empty states, missing data, and API failures. Adding robust testing increases codebase resilience against uncaught UI regressions when no data is loaded.

Impact:
Zero logic changes. Test coverage metrics increased.

Measurement:
Tests successfully run under the Jest runner validating the mocked edge cases and early exits.

---
*PR created automatically by Jules for task [233058094061473952](https://jules.google.com/task/233058094061473952) started by @ryusoh*