### PR TITLE
feat(ui): unify motion curve, reduce latency, and introduce typography contrast

### DIFF
--- a/css/analysis-proto.css
+++ b/css/analysis-proto.css
@@ -122,7 +122,7 @@ body {
     font-family: var(--font-mono);
     font-size: 0.9rem;
     cursor: pointer;
-    transition: all 0.2s ease;
+    transition: all 0.2s cubic-bezier(0.65, 0.05, 0, 1);
     text-transform: uppercase;
     white-space: nowrap;
 }

--- a/css/base.css
+++ b/css/base.css
@@ -1,3 +1,4 @@
+@import url('https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400..900;1,400..900&display=swap');
 /* JetBrains Mono – regular and italics */
 @font-face {
     font-family: 'JetBrains Mono';
@@ -117,4 +118,18 @@ footer a:focus-visible {
     outline: 2px solid rgba(255, 255, 255, 0.5);
     outline-offset: 4px;
     border-radius: 4px;
+}
+
+h1, h2, h3, h4, h5, h6 {
+    font-family: 'Playfair Display', serif;
+    font-weight: 700;
+}
+
+/* Hide scaffolding globally */
+::-webkit-scrollbar {
+    display: none;
+}
+* {
+    -ms-overflow-style: none;
+    scrollbar-width: none;
 }

--- a/css/calendar.css
+++ b/css/calendar.css
@@ -43,7 +43,7 @@ body.body-calendar {
 #cal-heatmap {
     width: auto;
     max-width: 100%;
-    transition: all 0.3s cubic-bezier(0.23, 1, 0.32, 1);
+    transition: all 0.3s cubic-bezier(0.65, 0.05, 0, 1);
     /* Smooth resize transitions */
 }
 
@@ -139,9 +139,9 @@ body.body-calendar {
     cursor: pointer;
     font-size: 24px;
     transition:
-        color 0.3s cubic-bezier(0.25, 0.8, 0.25, 1),
-        transform 0.2s cubic-bezier(0.25, 0.8, 0.25, 1),
-        filter 0.3s ease;
+        color 0.3s cubic-bezier(0.65, 0.05, 0, 1),
+        transform 0.2s cubic-bezier(0.65, 0.05, 0, 1),
+        filter 0.3s cubic-bezier(0.65, 0.05, 0, 1);
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -242,8 +242,8 @@ body.body-calendar {
     pointer-events: none;
     filter: drop-shadow(0 0.5px 0.5px rgba(0, 0, 0, 0.6));
     transition:
-        opacity 0.4s cubic-bezier(0.25, 0.8, 0.25, 1),
-        transform 0.4s cubic-bezier(0.25, 0.8, 0.25, 1);
+        opacity 0.3s cubic-bezier(0.65, 0.05, 0, 1),
+        transform 0.3s cubic-bezier(0.65, 0.05, 0, 1);
 }
 
 .subdomain-line1 {
@@ -286,7 +286,7 @@ body.body-calendar {
 
 /* Zoom functionality */
 .page-center-wrapper {
-    transition: all 0.4s cubic-bezier(0.23, 1, 0.32, 1);
+    transition: all 0.3s cubic-bezier(0.65, 0.05, 0, 1);
     width: 100%;
     background-color: rgba(44, 44, 46, 0);
     border-radius: 0px;
@@ -358,7 +358,7 @@ body.body-calendar {
 
 .page-center-wrapper.zoomed.sweeping::before {
     /* The Sweep Animation - Triggered by JS for precise interval control */
-    animation: optic-sweep var(--optic-sweep-duration, 5s) cubic-bezier(0.35, 0, 0.25, 1) forwards;
+    animation: optic-sweep var(--optic-sweep-duration, 5s) cubic-bezier(0.65, 0.05, 0, 1) forwards;
 }
 
 @keyframes optic-sweep {
@@ -395,7 +395,7 @@ body.body-calendar {
         background: rgba(0, 0, 0, 0.35);
         z-index: 50;
         pointer-events: none;
-        transition: background 0.25s ease;
+        transition: background 0.25s cubic-bezier(0.65, 0.05, 0, 1);
     }
 
     body.body-calendar.calendar-zoomed #calendar-mobile-overlay {

--- a/css/container.css
+++ b/css/container.css
@@ -40,10 +40,10 @@
     position: relative;
     /* Match Currency Toggle Transition */
     transition:
-        background-color 0.3s ease-in-out,
-        border-radius 0.3s ease-in-out,
-        box-shadow 0.3s ease-in-out,
-        color 0.2s ease;
+        background-color 0.3s cubic-bezier(0.65, 0.05, 0, 1),
+        border-radius 0.3s cubic-bezier(0.65, 0.05, 0, 1),
+        box-shadow 0.3s cubic-bezier(0.65, 0.05, 0, 1),
+        color 0.2s cubic-bezier(0.65, 0.05, 0, 1);
     outline: none;
 }
 
@@ -231,8 +231,8 @@
         width: auto;
         height: auto;
         transition:
-            color 0.3s ease,
-            transform 0.2s ease;
+            color 0.3s cubic-bezier(0.65, 0.05, 0, 1),
+            transform 0.2s cubic-bezier(0.65, 0.05, 0, 1);
     }
 
     .container a:hover,

--- a/css/cursor.css
+++ b/css/cursor.css
@@ -41,7 +41,7 @@ html.force-hide-cursor .custom-cursor {
     height: 20px;
     border: 2px solid #fff;
     border-radius: 50%;
-    transition: transform 0.15s ease;
+    transition: transform 0.15s cubic-bezier(0.65, 0.05, 0, 1);
     transform: scale(1);
     will-change: transform;
     background: transparent;

--- a/css/main_index.css
+++ b/css/main_index.css
@@ -39,7 +39,7 @@ body.body-main {
         mix-blend-mode: difference;
         opacity: 0;
         visibility: hidden;
-        transition: opacity 0.3s ease;
+        transition: opacity 0.3s cubic-bezier(0.65, 0.05, 0, 1);
     }
 
     .mobile-banner.is-fallback-ready {
@@ -95,7 +95,7 @@ h1 {
         opacity: 0;
         visibility: hidden;
         transition:
-            opacity 0.3s ease,
+            opacity 0.3s cubic-bezier(0.65, 0.05, 0, 1),
             visibility 0s linear 0.3s;
     }
 

--- a/css/perf.css
+++ b/css/perf.css
@@ -4,6 +4,6 @@ body.is-preload #bg {
 }
 
 #bg {
-    transition: opacity 1s ease-in-out;
+    transition: opacity 0.3s cubic-bezier(0.65, 0.05, 0, 1);
     opacity: 1;
 }

--- a/css/terminal/terminal.css
+++ b/css/terminal/terminal.css
@@ -83,8 +83,8 @@
     opacity: 0;
     visibility: hidden;
     transition:
-        opacity 120ms ease,
-        visibility 120ms ease;
+        opacity 120ms cubic-bezier(0.65, 0.05, 0, 1),
+        visibility 120ms cubic-bezier(0.65, 0.05, 0, 1);
     background: rgba(7, 9, 15, 0.12);
     z-index: 25;
 }

--- a/css/toggle.css
+++ b/css/toggle.css
@@ -40,9 +40,9 @@
     font-family:
         -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; /* System font for iOS feel */
     transition:
-        background-color 0.3s ease-in-out,
-        border-radius 0.3s ease-in-out,
-        box-shadow 0.3s ease-in-out;
+        background-color 0.3s cubic-bezier(0.65, 0.05, 0, 1),
+        border-radius 0.3s cubic-bezier(0.65, 0.05, 0, 1),
+        box-shadow 0.3s cubic-bezier(0.65, 0.05, 0, 1);
     outline: none;
 }
 
@@ -91,8 +91,8 @@
         transform: translateY(-50%) translateX(110%);
         opacity: 0;
         transition:
-            transform 0.6s cubic-bezier(0.23, 1, 0.32, 1),
-            opacity 0.4s ease;
+            transform 0.3s cubic-bezier(0.65, 0.05, 0, 1),
+            opacity 0.3s cubic-bezier(0.65, 0.05, 0, 1);
     }
 
     .body-calendar #currencyToggleContainer.chart-loaded {
@@ -105,8 +105,8 @@
         transform: translateY(-50%) translateX(100%) !important; /* Initially hide off-screen to the right */
         opacity: 0 !important; /* Initially invisible */
         transition:
-            transform 0.6s cubic-bezier(0.23, 1, 0.32, 1),
-            opacity 0.4s ease !important;
+            transform 0.3s cubic-bezier(0.65, 0.05, 0, 1),
+            opacity 0.3s cubic-bezier(0.65, 0.05, 0, 1) !important;
     }
 
     /* Show toggle after pie chart loads with slide-in animation */

--- a/js/pages/calendar/index.js
+++ b/js/pages/calendar/index.js
@@ -308,7 +308,7 @@ export function renderLabels(cal, byDate, state, currencySymbols) {
                 fadeOutSelection
                     .transition()
                     .duration(400)
-                    .ease(d3.easeCubicInOut)
+                    .ease(d3.easeCubicOut)
                     .style('opacity', 0)
                     .on('end', function () {
                         d3.select(this).text('');
@@ -393,7 +393,7 @@ export function renderLabels(cal, byDate, state, currencySymbols) {
                 .style('opacity', 0)
                 .transition()
                 .duration(400)
-                .ease(d3.easeCubicInOut)
+                .ease(d3.easeCubicOut)
                 .style('opacity', 1)
                 .on('end', function () {
                     state.isAnimating = false;

--- a/js/ui/calendarMonthLabelManager.js
+++ b/js/ui/calendarMonthLabelManager.js
@@ -347,7 +347,7 @@ export function updateMonthLabels(d3Instance, state, currencySymbols) {
                     .interrupt()
                     .transition()
                     .duration(transitionDuration)
-                    .ease(d3Instance.easeCubicInOut)
+                    .ease(d3Instance.easeCubicOut)
                     .attr('opacity', 0);
             }
         }
@@ -407,7 +407,7 @@ export function updateMonthLabels(d3Instance, state, currencySymbols) {
                     backgroundRect
                         .transition()
                         .duration(transitionDuration)
-                        .ease(d3Instance.easeCubicInOut)
+                        .ease(d3Instance.easeCubicOut)
                         .attr('opacity', 0);
                 }
             }
@@ -498,7 +498,7 @@ export function updateMonthLabels(d3Instance, state, currencySymbols) {
                 .interrupt()
                 .transition()
                 .duration(transitionDuration)
-                .ease(d3Instance.easeCubicInOut)
+                .ease(d3Instance.easeCubicOut)
                 .attr('opacity', 0);
         }
 

--- a/js/ui/magnetic_nav.js
+++ b/js/ui/magnetic_nav.js
@@ -34,7 +34,7 @@ export function initMagneticNav() {
                 x: distX * strength,
                 y: distY * strength,
                 duration: 0.3,
-                ease: 'power2.out',
+                ease: 'power3.out',
             });
 
             // Pull the child element (e.g. <a> or <i>) slightly more for a parallax effect
@@ -44,7 +44,7 @@ export function initMagneticNav() {
                     x: distX * (strength * 1.5),
                     y: distY * (strength * 1.5),
                     duration: 0.3,
-                    ease: 'power2.out',
+                    ease: 'power3.out',
                 });
             }
         });
@@ -54,8 +54,8 @@ export function initMagneticNav() {
             window.gsap.to(el, {
                 x: 0,
                 y: 0,
-                duration: 0.7,
-                ease: 'elastic.out(1, 0.3)',
+                duration: 0.3,
+                ease: 'power3.out',
             });
 
             const child = el.querySelector('a, i');
@@ -63,8 +63,8 @@ export function initMagneticNav() {
                 window.gsap.to(child, {
                     x: 0,
                     y: 0,
-                    duration: 0.7,
-                    ease: 'elastic.out(1, 0.3)',
+                    duration: 0.3,
+                    ease: 'power3.out',
                 });
             }
         });

--- a/js/ui/tilt_effect.js
+++ b/js/ui/tilt_effect.js
@@ -26,8 +26,8 @@ export function initTiltEffect() {
             window.gsap.to(container, {
                 rotateX: rotateX,
                 rotateY: rotateY,
-                duration: 0.5,
-                ease: 'power2.out',
+                duration: 0.3,
+                ease: 'power3.out',
                 overwrite: true,
             });
         });
@@ -35,8 +35,8 @@ export function initTiltEffect() {
             window.gsap.to(container, {
                 rotateX: 0,
                 rotateY: 0,
-                duration: 1,
-                ease: 'elastic.out(1, 0.3)',
+                duration: 0.3,
+                ease: 'power3.out',
                 overwrite: true,
             });
         });

--- a/tests/js/ui/magnetic_nav.test.js
+++ b/tests/js/ui/magnetic_nav.test.js
@@ -102,7 +102,7 @@ describe('Magnetic Nav', () => {
             expect.objectContaining({
                 x: 0,
                 y: 0,
-                ease: 'elastic.out(1, 0.3)',
+                ease: 'power3.out',
             })
         );
     });
@@ -139,7 +139,7 @@ describe('Magnetic Nav', () => {
             expect.objectContaining({
                 x: 0,
                 y: 0,
-                ease: 'elastic.out(1, 0.3)',
+                ease: 'power3.out',
             })
         );
     });

--- a/tests/js/ui/tilt_effect.test.js
+++ b/tests/js/ui/tilt_effect.test.js
@@ -108,8 +108,8 @@ describe('tilt_effect', () => {
         expect(window.gsap.to).toHaveBeenCalledWith(container, {
             rotateX: 5,
             rotateY: -5,
-            duration: 0.5,
-            ease: 'power2.out',
+            duration: 0.3,
+            ease: 'power3.out',
             overwrite: true,
         });
     });
@@ -125,8 +125,8 @@ describe('tilt_effect', () => {
         expect(window.gsap.to).toHaveBeenCalledWith(container, {
             rotateX: 0,
             rotateY: 0,
-            duration: 1,
-            ease: 'elastic.out(1, 0.3)',
+            duration: 0.3,
+            ease: 'power3.out',
             overwrite: true,
         });
     });


### PR DESCRIPTION
What:
- Unified all CSS and JS (GSAP, D3) animations to a single aggressive ease-out curve (`cubic-bezier(0.65, 0.05, 0, 1)`, `power3.out`).
- Reduced maximum animation durations to 0.3s across the board.
- Replaced native scrollbars with hidden scrollbars globally (`::-webkit-scrollbar { display: none; }`).
- Imported `Playfair Display` and applied it to headings for a serif/sans-serif dramatic contrast setup alongside `JetBrains Mono`.

Why:
- To adhere to minimal latency principles (Steve Jobs test). Any animation that adds latency "for polish" wastes user time.
- To unify the motion brand across all components (Lando Norris test). A single easing curve separates "designed" from "decorated" by creating a consistent narrative and predictable UI response.
- To create a more app-like visual structure by removing default browser scaffolding (scrollbars).

Impact:
- The interface feels noticeably faster, snappier, and cohesive without losing core interactive visual cues.
- The dual-font system significantly enhances typographical hierarchy without adding layout bloat.

Measurement:
- Passing Jest test suite after updating mock assertions for GSAP timings.
- `pnpm run verify:all` clean execution.

---
*PR created automatically by Jules for task [6654432760345285869](https://jules.google.com/task/6654432760345285869) started by @ryusoh*