### PR TITLE
Palette: Add aria-live region to portfolio table summary

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -81,3 +81,6 @@
 **Action:** Do not add `tabindex="0"` to non-interactive structural or layout layout containers. Let the user scroll naturally without forcing focus onto the layout structure itself.
 
 ## 2026-05-08 - Accessible Toggle Bootstrap\n\n**Learning:** During page load bootstrap scripts that restore UI toggle states (like currency toggles) without a framework, the initialization script often updates the visual CSS class (`active`) but forgets to sync the corresponding ARIA attribute (`aria-pressed`). This creates a mismatch for screen readers, announcing an incorrect state on initial load.\n\n**Action:** Always ensure that bootstrap scripts that manually modify `.active` CSS classes on toggles also explicitly update the `aria-pressed` attribute to maintain accessibility parity.\n
+## 2026-05-14 - Dynamic Content Accessibility
+**Learning:** Asynchronous data updates in footers or summaries are missed by screen readers unless explicitly marked.
+**Action:** Add `aria-live="polite"` to parent containers or footers (e.g., `#table-footer-summary`) that are dynamically populated.

--- a/position/index.html
+++ b/position/index.html
@@ -165,7 +165,7 @@
             </div>
 
             <div class="footer-wrapper hidden">
-                <div id="table-footer-summary">
+                <div id="table-footer-summary" aria-live="polite">
                     TOTAL <span id="total-portfolio-value-in-table">$0.00</span
                     ><span class="total-pnl"></span>
                 </div>

--- a/tests/js/services/dataService.test.js
+++ b/tests/js/services/dataService.test.js
@@ -56,7 +56,7 @@ describe('dataService', () => {
                 <tbody></tbody>
             </table>
             <div id="total-portfolio-value-in-table"></div>
-            <div id="table-footer-summary">
+            <div id="table-footer-summary" aria-live="polite">
                 <span class="total-pnl"></span>
             </div>
         `;


### PR DESCRIPTION
What: Added aria-live="polite" to the table footer summary (#table-footer-summary) in the Position page.
Why: The total portfolio value and PnL are dynamically calculated and updated asynchronously. Without an ARIA live region, screen readers do not announce these updates to users.
Accessibility: Improves screen reader support by naturally announcing asynchronous updates to the total portfolio value and PnL.

---
*PR created automatically by Jules for task [9006082687411377650](https://jules.google.com/task/9006082687411377650) started by @ryusoh*