### PR TITLE
⚡ Bolt: Cache Intl.NumberFormat in stats parsing/formatting

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -192,3 +192,8 @@
 
 **Learning:** Instantiating `Intl.NumberFormat` and repeatedly calling `toLocaleString` within a loop is significantly slower than caching an `Intl.NumberFormat` object and reusing its `.format()` method. In a performance test with 100k iterations, `toLocaleString` took over 4.3 seconds whereas caching `Intl.NumberFormat` took under 200ms.
 **Action:** When executing high-frequency currency or number formatting functions (e.g. `formatCurrency` used frequently during rendering lists or tooltips), cache the `Intl.NumberFormat` instance using a Map. Avoid calling `.toLocaleString()` dynamically where a single instantiation could be reused.
+
+## 2026-05-14 - Cache Intl.NumberFormat in formatting utilities
+
+**Learning:** Instantiating `Intl.NumberFormat` and repeatedly calling `toLocaleString` within a loop is significantly slower than caching an `Intl.NumberFormat` object and reusing its `.format()` method.
+**Action:** Replaced dynamic `.toLocaleString()` calls with the cached `getNumberFormatter()` in formatting loops in `holdings.js`, `transactions.js`, `analysis.js` and `calendar/index.js` to avoid recreation overhead and decrease latency.

--- a/js/pages/calendar/index.js
+++ b/js/pages/calendar/index.js
@@ -1,3 +1,4 @@
+import { getNumberFormatter } from '@utils/formatting.js';
 import {
     initCurrencyToggle,
     cycleCurrency,
@@ -1074,7 +1075,7 @@ export async function initCalendar() {
                 const pnlPercent = (value * 100).toFixed(2);
                 /* istanbul ignore next: tooltip function implementation */
                 const totalValue = entry
-                    ? entry.total.toLocaleString('en-US', { style: 'currency', currency: 'USD' })
+                    ? getNumberFormatter('en-US', 2, 2, { style: 'currency', currency: 'USD' }).format(entry.total)
                     : 'N/A';
                 /* istanbul ignore next: tooltip function implementation */
                 const sign = value > 0 ? '+' : '';

--- a/js/transactions/terminal/stats/analysis.js
+++ b/js/transactions/terminal/stats/analysis.js
@@ -1,3 +1,4 @@
+import { getNumberFormatter } from '../../../utils/formatting.js';
 import { transactionState } from '../../state.js';
 import { getSplitAdjustment } from '../../calculations.js';
 import { loadCompositionSnapshotData } from '../../dataLoader.js';
@@ -352,13 +353,13 @@ export async function getDurationStatsText() {
         summaryRows.push([
             'Weighted Avg Age (Open)',
             Number.isFinite(weightedAvgDays)
-                ? `${Math.round(weightedAvgDays).toLocaleString()} days (${formatDurationLabel(weightedAvgDays)})`
+                ? `${getNumberFormatter(undefined, 0, 0).format(Math.round(weightedAvgDays))} days (${formatDurationLabel(weightedAvgDays)})`
                 : 'N/A',
         ]);
         summaryRows.push([
             'Weighted Median Age (Open)',
             Number.isFinite(medianDays)
-                ? `${Math.round(medianDays).toLocaleString()} days (${formatDurationLabel(medianDays)})`
+                ? `${getNumberFormatter(undefined, 0, 0).format(Math.round(medianDays))} days (${formatDurationLabel(medianDays)})`
                 : 'N/A',
         ]);
     }
@@ -376,7 +377,7 @@ export async function getDurationStatsText() {
     if (Number.isFinite(weightedClosedAvgDays)) {
         summaryRows.push([
             'Weighted Avg Age (Closed)',
-            `${Math.round(weightedClosedAvgDays).toLocaleString()} days (${formatDurationLabel(
+            `${getNumberFormatter(undefined, 0, 0).format(Math.round(weightedClosedAvgDays))} days (${formatDurationLabel(
                 weightedClosedAvgDays
             )})`,
         ]);
@@ -396,7 +397,7 @@ export async function getDurationStatsText() {
     if (Number.isFinite(weightedAvgAll)) {
         summaryRows.push([
             'Weighted Avg Age (All)',
-            `${Math.round(weightedAvgAll).toLocaleString()} days (${formatDurationLabel(
+            `${getNumberFormatter(undefined, 0, 0).format(Math.round(weightedAvgAll))} days (${formatDurationLabel(
                 weightedAvgAll
             )})`,
         ]);
@@ -416,7 +417,7 @@ export async function getDurationStatsText() {
         .map((entry) => [
             entry.ticker,
             `${entry.percent.toFixed(2)}%`,
-            Math.round(entry.avgAgeDays).toLocaleString(),
+            getNumberFormatter(undefined, 0, 0).format(Math.round(entry.avgAgeDays)),
             formatYearsValue(entry.avgAgeDays),
         ]);
 
@@ -485,7 +486,7 @@ export async function getLifespanStatsText() {
         .map((entry) => [
             entry.ticker,
             formatShareValueShort(entry.openShares),
-            Math.round(entry.spanDays).toLocaleString(),
+            getNumberFormatter(undefined, 0, 0).format(Math.round(entry.spanDays)),
             formatYearsValue(entry.spanDays),
         ]);
 
@@ -519,7 +520,7 @@ export async function getLifespanStatsText() {
         .map((entry) => [
             entry.ticker,
             formatShareValueShort(entry.shares),
-            Math.round(entry.spanDays).toLocaleString(),
+            getNumberFormatter(undefined, 0, 0).format(Math.round(entry.spanDays)),
             formatYearsValue(entry.spanDays),
         ]);
 
@@ -554,7 +555,7 @@ export async function getLifespanStatsText() {
     if (Number.isFinite(weightedAvgOpen)) {
         summaryRows.push([
             'Weighted Avg (Open)',
-            `${Math.round(weightedAvgOpen).toLocaleString()} days (${formatDurationLabel(
+            `${getNumberFormatter(undefined, 0, 0).format(Math.round(weightedAvgOpen))} days (${formatDurationLabel(
                 weightedAvgOpen
             )})`,
         ]);
@@ -562,7 +563,7 @@ export async function getLifespanStatsText() {
     if (Number.isFinite(weightedAvgClosed)) {
         summaryRows.push([
             'Weighted Avg (Closed)',
-            `${Math.round(weightedAvgClosed).toLocaleString()} days (${formatDurationLabel(
+            `${getNumberFormatter(undefined, 0, 0).format(Math.round(weightedAvgClosed))} days (${formatDurationLabel(
                 weightedAvgClosed
             )})`,
         ]);
@@ -570,7 +571,7 @@ export async function getLifespanStatsText() {
     if (Number.isFinite(weightedAvgAll)) {
         summaryRows.push([
             'Weighted Avg (All)',
-            `${Math.round(weightedAvgAll).toLocaleString()} days (${formatDurationLabel(
+            `${getNumberFormatter(undefined, 0, 0).format(Math.round(weightedAvgAll))} days (${formatDurationLabel(
                 weightedAvgAll
             )})`,
         ]);
@@ -578,13 +579,13 @@ export async function getLifespanStatsText() {
     if (openEntries.length) {
         summaryRows.push([
             'Longest Open Position',
-            `${openEntries[0].ticker} · ${Math.round(openEntries[0].spanDays).toLocaleString()} days`,
+            `${openEntries[0].ticker} · ${getNumberFormatter(undefined, 0, 0).format(Math.round(openEntries[0].spanDays))} days`,
         ]);
     }
     if (closedEntries.length) {
         summaryRows.push([
             'Longest Closed Position',
-            `${closedEntries[0].ticker} · ${Math.round(closedEntries[0].spanDays).toLocaleString()} days`,
+            `${closedEntries[0].ticker} · ${getNumberFormatter(undefined, 0, 0).format(Math.round(closedEntries[0].spanDays))} days`,
         ]);
     }
     if (!openEntries.length && !closedEntries.length) {

--- a/js/transactions/terminal/stats/holdings.js
+++ b/js/transactions/terminal/stats/holdings.js
@@ -1,3 +1,4 @@
+import { getNumberFormatter } from '../../../utils/formatting.js';
 import { formatCurrency } from '../../utils.js';
 import {
     renderAsciiTable,
@@ -28,10 +29,7 @@ export async function getHoldingsText(currency = 'USD') {
                 return 'No current holdings.';
             }
             const rows = currencyData.map((item) => {
-                const shares = Number(item.shares || 0).toLocaleString(undefined, {
-                    minimumFractionDigits: 2,
-                    maximumFractionDigits: 2,
-                });
+                const shares = getNumberFormatter(undefined, 2, 2).format(Number(item.shares || 0));
                 const avgPrice =
                     item.average_price !== null && item.average_price !== undefined
                         ? formatCurrency(item.average_price, { currency: normalizedCurrency })

--- a/js/transactions/terminal/stats/transactions.js
+++ b/js/transactions/terminal/stats/transactions.js
@@ -1,3 +1,4 @@
+import { getNumberFormatter } from '../../../utils/formatting.js';
 import { formatCurrency } from '../../utils.js';
 import { transactionState } from '../../state.js';
 import { renderAsciiTable } from './formatting.js';
@@ -34,7 +35,7 @@ export async function getDynamicStatsText(currency = 'USD') {
     const netInvested = totalBuy - totalSell; // Cost - Proceeds. Positive = Net Invested (Cash Out). Negative = Net Divested (Cash In).
 
     const rows = [
-        ['Transactions', count.toLocaleString()],
+        ['Transactions', getNumberFormatter(undefined, 0, 0).format(count)],
         ['Total Buy', formatCurrency(totalBuy, { currency: normalizedCurrency })],
         ['Total Sell', formatCurrency(totalSell, { currency: normalizedCurrency })],
         ['Net Invested', formatCurrency(netInvested, { currency: normalizedCurrency })],
@@ -70,9 +71,9 @@ export async function getStatsText(currency = 'USD') {
             const counts = statsDataCache.counts || {};
             const values = availableCurrencies[selectedCurrency] || {};
             const rows = [
-                ['Total Transactions', Number(counts.total_transactions || 0).toLocaleString()],
-                ['Buy Orders', Number(counts.buy_orders || 0).toLocaleString()],
-                ['Sell Orders', Number(counts.sell_orders || 0).toLocaleString()],
+                ['Total Transactions', getNumberFormatter(undefined, 0, 0).format(Number(counts.total_transactions || 0))],
+                ['Buy Orders', getNumberFormatter(undefined, 0, 0).format(Number(counts.buy_orders || 0))],
+                ['Sell Orders', getNumberFormatter(undefined, 0, 0).format(Number(counts.sell_orders || 0))],
                 [
                     'Total Buy Amount',
                     formatCurrency(values.total_buy_amount || 0, { currency: selectedCurrency }),

--- a/js/utils/formatting.js
+++ b/js/utils/formatting.js
@@ -2,13 +2,15 @@ import { logger } from './logger.js';
 
 // Bolt: Cache Intl.NumberFormat instances to prevent expensive recreation and speed up formatCurrency
 const numberFormatCache = new Map();
-export function getNumberFormatter(locale = undefined, minFrac = 2, maxFrac = 2) {
-    const key = `${locale}-${minFrac}-${maxFrac}`;
+export function getNumberFormatter(locale = undefined, minFrac = 2, maxFrac = 2, extraOptions = {}) {
+    const extraKey = Object.keys(extraOptions).length ? JSON.stringify(extraOptions) : '';
+    const key = `${locale}-${minFrac}-${maxFrac}-${extraKey}`;
     let formatter = numberFormatCache.get(key);
     if (!formatter) {
         formatter = new Intl.NumberFormat(locale, {
             minimumFractionDigits: minFrac,
             maximumFractionDigits: maxFrac,
+            ...extraOptions
         });
         numberFormatCache.set(key, formatter);
     }


### PR DESCRIPTION
💡 What: Replaced dynamic `.toLocaleString()` usages in `holdings.js`, `transactions.js`, `analysis.js` and `calendar/index.js` with the cached `getNumberFormatter()` method. Added the entry to `.jules/bolt.md`.
🎯 Why: Instantiating `Intl.NumberFormat` and repeatedly calling `toLocaleString` within loops is significantly slower than caching the `Intl.NumberFormat` object and reusing its `.format()` method. 
📊 Impact: Substantially reduces overhead during heavy loop mapping.
🔬 Measurement: Verify tests run fine and code metrics logic isn't impacted.

---
*PR created automatically by Jules for task [3100171169290025434](https://jules.google.com/task/3100171169290025434) started by @ryusoh*