### PR TITLE
Sentinel: Add security headers to API worker and static assets

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -48,3 +48,7 @@ error_msg = error_msg.replace(urllib.parse.quote(api_key), "***")
 **Vulnerability:** The CORS validation logic in `worker/src/index.js` checked if the Origin header ended with `.lyeutsaon.com` using a simple string `endsWith` method. This allowed a malicious origin like `https://malicious.lyeutsaon.com.evil.com` to bypass CORS validation. Also, since there was no protocol check, a `http:` scheme would also be permitted.
 **Learning:** Naive string manipulation for Origin validation is insecure, especially since browsers pass the entire scheme+hostname+port in the Origin header. Validation must isolate the hostname.
 **Prevention:** Always use the `URL` constructor to securely parse the `hostname` and explicitly enforce the `https:` protocol when verifying CORS Origins.
+## 2024-05-14 - Added Security Headers
+**Vulnerability:** Missing security headers.
+**Learning:** Static site headers in Cloudflare Pages are configured via `_headers`. API worker responses need headers set programmatically in `worker/src/index.js`.
+**Prevention:** Always verify both static asset delivery (via `_headers`) and API response generation (via `Response` objects in workers) include necessary security headers like `Content-Security-Policy` and `X-Content-Type-Options`.

--- a/_headers
+++ b/_headers
@@ -4,3 +4,4 @@
   Referrer-Policy: strict-origin-when-cross-origin
   Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
   Permissions-Policy: geolocation=(), microphone=(), camera=(), payment=()
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://unpkg.com https://cdn.bootcdn.net https://cdn.baomitu.com; font-src 'self' data: https://fonts.gstatic.com https://unpkg.com https://cdn.bootcdn.net https://cdn.baomitu.com; img-src 'self' data:; connect-src 'self' https://api.lyeutsaon.com; media-src 'self'; frame-src 'none'; object-src 'none';

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -75,6 +75,7 @@ function jsonResponse(data, status, origin, extraHeaders = {}) {
         status,
         headers: {
             'Content-Type': 'application/json',
+            'X-Content-Type-Options': 'nosniff',
             ...corsHeaders(origin),
             ...extraHeaders,
         },
@@ -303,7 +304,7 @@ export default {
 
         // Handle CORS preflight
         if (request.method === 'OPTIONS') {
-            return new Response(null, { status: 204, headers: corsHeaders(origin) });
+            return new Response(null, { status: 204, headers: { ...corsHeaders(origin), 'X-Content-Type-Options': 'nosniff' } });
         }
 
         const url = new URL(request.url);


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing security headers like Content-Security-Policy on static assets and X-Content-Type-Options on worker API responses.
🎯 Impact: Attackers could potentially exploit missing CSP on the static site or mime-sniffing vulnerabilities on the API endpoint.
🔧 Fix: Appended CSP to `_headers` and added `X-Content-Type-Options: nosniff` to API responses in `worker/src/index.js`.
✅ Verification: Ran `pnpm run verify:all` locally.

---
*PR created automatically by Jules for task [6468766431009329756](https://jules.google.com/task/6468766431009329756) started by @ryusoh*