### PR TITLE
Fix: Resolve silent failures in UI catch blocks

### DIFF
--- a/.jules/janitor.md
+++ b/.jules/janitor.md
@@ -36,3 +36,8 @@
 
 - **Issue:** Several Python scripts suppressed exceptions using `except: pass` which could lead to silent data processing failures.
 - **Action:** Audited the codebase to replace empty catch blocks with proper warning logs or print statements to ensure exceptions are visible and resilience is maintained.
+
+## 2024-05-14 - Sentinel Catch Blocks Fixes
+
+- **Issue:** Several global scripts and UI modules had completely empty `catch` blocks or `catch` closures that blindly returned without logging, risking silent failures across various async operations (video warmup, prefetching, and font loading).
+- **Action:** Audited the codebase for empty `catch` blocks and modified `icon_font_ready.js`, `videoFallback.js`, `video_warmup.js`, and `nav_prefetch.js`. Added `console.warn` statements to correctly log the rejected promises and error conditions, ensuring failures are trackable without disrupting the user flow. Verified with test suite which remains 100% green.

--- a/js/ui/icon_font_ready.js
+++ b/js/ui/icon_font_ready.js
@@ -25,7 +25,9 @@
         if (document.fonts && document.fonts.load) {
             Promise.all([
                 document.fonts.load('1em FontAwesome'),
-                document.fonts.ready.catch(function () {
+                document.fonts.ready.catch(function (error) {
+                    // eslint-disable-next-line no-console
+                    console.warn('Icon font ready promise rejected:', error);
                     return undefined;
                 }),
             ])

--- a/js/ui/nav_prefetch.js
+++ b/js/ui/nav_prefetch.js
@@ -144,7 +144,11 @@
                 options.mode = 'no-cors';
             }
 
-            return fetch(fetchUrl.href, options).catch(() => undefined);
+            return fetch(fetchUrl.href, options).catch((error) => {
+                // eslint-disable-next-line no-console
+                console.warn('Prefetch request failed:', error);
+                return undefined;
+            });
         });
     }
 
@@ -160,7 +164,11 @@
             const task = queue.shift();
             Promise.resolve()
                 .then(task)
-                .catch(() => undefined)
+                .catch((error) => {
+                    // eslint-disable-next-line no-console
+                    console.warn('Prefetch task failed:', error);
+                    return undefined;
+                })
                 .finally(() => {
                     if (queue.length) {
                         if ('requestIdleCallback' in window) {
@@ -215,7 +223,9 @@
             });
 
             tasks.push(
-                discoveryTask.catch(() => {
+                discoveryTask.catch((error) => {
+                    // eslint-disable-next-line no-console
+                    console.warn('Discovery task failed:', error);
                     return undefined;
                 })
             );
@@ -234,7 +244,11 @@
                 }
                 return res.text().then((text) => extractBackgroundUrls(text, cssUrl));
             })
-            .catch(() => []);
+            .catch((error) => {
+                // eslint-disable-next-line no-console
+                console.warn('CSS background fetch failed:', error);
+                return [];
+            });
     }
 
     function extractBackgroundUrls(cssText, cssUrl) {

--- a/js/ui/videoFallback.js
+++ b/js/ui/videoFallback.js
@@ -30,7 +30,9 @@ export function initVideoFallback() {
     const playPromise = video.play();
 
     if (playPromise !== undefined) {
-        playPromise.catch(() => {
+        playPromise.catch((error) => {
+            // eslint-disable-next-line no-console
+            console.warn('Video autoplay failed:', error);
             // Autoplay failed, use fallback
             fallbackToStaticImage();
         });

--- a/js/ui/video_warmup.js
+++ b/js/ui/video_warmup.js
@@ -55,9 +55,20 @@
                         return globalScope.caches
                             .open(CACHE_NAME)
                             .then((cache) => cache.add(absoluteUrl))
-                            .catch(() => warmFetchFallback(absoluteUrl));
+                            .catch((error) => {
+                                // eslint-disable-next-line no-console
+                                console.warn(
+                                    'Video warmup fallback triggered due to error:',
+                                    error
+                                );
+                                return warmFetchFallback(absoluteUrl);
+                            });
                     })
-                    .catch(() => warmFetchFallback(absoluteUrl));
+                    .catch((error) => {
+                        // eslint-disable-next-line no-console
+                        console.warn('Video warmup fallback triggered due to error:', error);
+                        return warmFetchFallback(absoluteUrl);
+                    });
             } else {
                 warmFetchFallback(absoluteUrl);
             }


### PR DESCRIPTION
**What**
- Removed silent failures by injecting `console.warn` into previously empty catch blocks or catch blocks that silently returned without logging in `js/ui/icon_font_ready.js`, `js/ui/videoFallback.js`, `js/ui/video_warmup.js`, and `js/ui/nav_prefetch.js`.
- Used `// eslint-disable-next-line no-console` where necessary to ensure the new warnings comply with the project's strict `pnpm lint` checks.
- Updated `.jules/janitor.md` with details of the investigation and remediation.

**Why**
- Silent catch blocks mask underlying issues such as resource loading timeouts, service worker exceptions, and network prefetching failures, making debugging significantly harder.
- Adding warnings preserves the exact same non-breaking functional flow but exposes these occurrences in the developer console.

**Impact**
- No functional change to user flows.
- Improved observability for async UI operations.

**Measurement**
- All 2033 Jest tests continue to pass 100%.
- ESLint checks pass 100%.

---
*PR created automatically by Jules for task [6746778825271048899](https://jules.google.com/task/6746778825271048899) started by @ryusoh*