### PR TITLE
Palette: Add explicit visual empty state for terminal charts

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -81,3 +81,7 @@
 **Action:** Do not add `tabindex="0"` to non-interactive structural or layout layout containers. Let the user scroll naturally without forcing focus onto the layout structure itself.
 
 ## 2026-05-08 - Accessible Toggle Bootstrap\n\n**Learning:** During page load bootstrap scripts that restore UI toggle states (like currency toggles) without a framework, the initialization script often updates the visual CSS class (`active`) but forgets to sync the corresponding ARIA attribute (`aria-pressed`). This creates a mismatch for screen readers, announcing an incorrect state on initial load.\n\n**Action:** Always ensure that bootstrap scripts that manually modify `.active` CSS classes on toggles also explicitly update the `aria-pressed` attribute to maintain accessibility parity.\n
+## 2026-05-13 - Visual Empty States for Data Visualization
+
+**Learning:** When data visualizations (like canvas-based charts) are completely empty due to filtering or lack of data, rendering a blank canvas or hiding the container leaves users confused, assuming the application is broken or stuck loading.
+**Action:** Always provide an explicit visual empty state (e.g., an overlay with an icon and a clear message like "No data available") when no data is available to render in the visualization.

--- a/css/terminal/chart.css
+++ b/css/terminal/chart.css
@@ -147,3 +147,26 @@
     border: none;
     align-self: center;
 }
+
+.chart-empty {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    color: var(--muted-text);
+    font-size: 14px;
+    pointer-events: none;
+    text-align: center;
+    gap: 12px;
+}
+
+.chart-empty::before {
+    content: '\f06a';
+    font-family: 'FontAwesome';
+    font-size: 24px;
+    color: rgba(255, 255, 255, 0.2);
+}

--- a/terminal/index.html
+++ b/terminal/index.html
@@ -166,7 +166,9 @@
                         role="img"
                         aria-label="Running amount chart"
                     ></canvas>
-                    <div class="chart-empty" id="runningAmountEmpty" style="display: none"></div>
+                    <div class="chart-empty" id="runningAmountEmpty" style="display: none">
+                        <span>No data available for the selected period</span>
+                    </div>
                 </div>
                 <div class="chart-legend"></div>
             </section>


### PR DESCRIPTION
What: Added an explicit visual empty state with a FontAwesome icon (via CSS) and a helpful message ("No data available for the selected period") to the terminal chart container.
Why: When the chart data is empty (e.g., heavily filtered), the canvas appears completely blank, leading users to assume the interface is broken or stuck loading.
Impact: Provides immediate, clear visual feedback when no data matches the current filters or time ranges.
Measurement: Users will encounter the clear message rather than a blank canvas when zooming into periods without activity.
Accessibility: Ensures the empty state is visible and clearly structured.

---
*PR created automatically by Jules for task [508547998908731384](https://jules.google.com/task/508547998908731384) started by @ryusoh*