### PR TITLE
🎨 Palette: Add .sr-only utility class to css/base.css

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -89,3 +89,8 @@
 
 **Learning:** Asynchronous data updates in footers or summaries are missed by screen readers unless explicitly marked.
 **Action:** Add `aria-live="polite"` to parent containers or footers (e.g., `#table-footer-summary`) that are dynamically populated.
+
+## 2026-05-15 - Explicitly Define Utility Classes for Accessibility
+
+**Learning:** The application uses utility classes like `.sr-only` for screen reader accessible labels (e.g., in `terminal/index.html`). However, because the project does not use a CSS framework like Tailwind or Bootstrap, the class was missing from the CSS, causing screen-reader-only text to be visually rendered.
+**Action:** Always ensure that any utility class used for accessibility (like `.sr-only`) is explicitly defined in the project's base CSS (`css/base.css`) so that it functions correctly without relying on external frameworks.

--- a/css/base.css
+++ b/css/base.css
@@ -118,3 +118,4 @@ footer a:focus-visible {
     outline-offset: 4px;
     border-radius: 4px;
 }
+.sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border-width: 0; }


### PR DESCRIPTION
💡 What: Added the `.sr-only` CSS utility class definition to `css/base.css`.
🎯 Why: The `terminal/index.html` file uses the `sr-only` class to hide labels (`<label for="terminalInput" class="sr-only">`) and headings (`<h2 id="runningAmountTitle" class="sr-only">`) from sighted users while keeping them accessible to screen readers. However, because the project doesn't use a CSS framework and the class wasn't defined in the custom CSS, the text was visually rendering on the screen, breaking the UI layout.
♿ Accessibility: Ensures that screen-reader-only text is correctly hidden visually but remains perfectly perceivable to assistive technologies.

---
*PR created automatically by Jules for task [11906932479054057919](https://jules.google.com/task/11906932479054057919) started by @ryusoh*