### PR TITLE
test: add unit tests for analysis lab, ambient effect, and composition renderer

### DIFF
--- a/.jules/testpilot.md
+++ b/.jules/testpilot.md
@@ -58,3 +58,5 @@ Result: Tested and verified gracefull exits for zero data/series, increasing sys
 ## 2025-05-11 - Fixed Date parsing coverage and Markdown regex matching
 
 **Learning:** When testing timezone-sensitive utilities like `parseLocalDate`, tests should explicitly assert against the local timezone output rather than hardcoded UTC equivalents. When testing regex text parsers, ensure edge cases like missing brackets or different types of quotes ('smart quotes') are explicitly mocked and handled.
+## 2024-05-24 - Test mocking patterns
+- **Pattern:** When unit testing IIFEs or scripts that evaluate on import and depend on global state (like URL parameters), call `jest.resetModules()` in `beforeEach()`, configure global mocks (e.g., mocking `window.URLSearchParams` globally with `jest.fn().mockImplementation()` instead of redefining `window.location` due to JSDOM constraints), and dynamically `require()` the script inside the test block.

--- a/js/pages/analysis/lab.js
+++ b/js/pages/analysis/lab.js
@@ -1065,5 +1065,5 @@ export const __analysisLabTesting = {
     aggregateScenarios,
     extractScenarioTitles,
     renderBayesOutput,
-    state,
+    state, normalizeConfig, buildPortfolioConfig,
 };

--- a/tests/js/ambient/ambient.test.js
+++ b/tests/js/ambient/ambient.test.js
@@ -89,7 +89,7 @@ describe('Ambient Logic', () => {
     });
 
     it('should initialize with debug settings', () => {
-        window.location = { search: '?ambient=debug' };
+        window.URLSearchParams = jest.fn().mockImplementation(() => ({ get: (key) => key === 'ambient' ? 'debug' : null }));
         require('../../../js/ambient/ambient.js');
         expect(window.Sketch.create).toHaveBeenCalled();
     });
@@ -159,5 +159,41 @@ describe('Ambient Logic', () => {
             'Caught exception in ambient setup:',
             expect.any(Error)
         );
+    });
+
+    it('sets minimum threshold correctly for debug configuration', () => {
+        // Change window.URLSearchParams behavior for debug using mock
+        window.URLSearchParams = jest.fn().mockImplementation(() => ({
+            get: (key) => key === 'ambient' ? 'debug' : null
+        }));
+        window.AMBIENT_CONFIG.densityDivisor = 20000;
+        window.AMBIENT_CONFIG.speed = 0.1;
+
+        require('../../../js/ambient/ambient.js');
+        const s = window.Sketch.create.mock.results[0].value;
+
+        // Verify Math.max logic worked
+        expect(window.Sketch.create).toHaveBeenCalled();
+        expect(s.canvas.style.zIndex).toBe("999");
+    });
+
+    it('handles particles array boundary cases during update and draw', () => {
+        window.URLSearchParams = jest.fn().mockImplementation(() => ({
+            get: (key) => key === 'ambient' ? 'on' : null
+        }));
+        window.AMBIENT_CONFIG.maxParticles = 5;
+        require('../../../js/ambient/ambient.js');
+
+        const s = window.Sketch.create.mock.results[0].value;
+        s.setup();
+
+        s.update();
+        s.height = -100;
+        s.update();
+        s.draw();
+
+        // Assertions verifying behavior
+        expect(s.arc).toHaveBeenCalled();
+        expect(s.fill).toHaveBeenCalled();
     });
 });

--- a/tests/js/pages/analysis/lab.test.js
+++ b/tests/js/pages/analysis/lab.test.js
@@ -199,4 +199,83 @@ describe('analysis lab data loading', () => {
             );
         });
     });
+
+    describe('normalizeConfig', () => {
+        it('normalizes a basic raw config correctly', async () => {
+            global[FLAG] = true;
+            const module = await import('@pages/analysis/lab.js');
+            const { normalizeConfig } = module.__analysisLabTesting;
+            const raw = {
+                symbol: 'TEST',
+                market: { price: '100', eps: '5' },
+                scenarios: []
+            };
+            const result = normalizeConfig(raw);
+            expect(result.symbol).toBe('TEST');
+            expect(result.market.price).toBe(100);
+            expect(result.market.eps).toBe(5);
+            expect(result.marketValue).toBe(0);
+        });
+
+        it('uses holdingDetails for fallback and calculates marketValue', async () => {
+            global[FLAG] = true;
+            const module = await import('@pages/analysis/lab.js');
+            const { normalizeConfig } = module.__analysisLabTesting;
+            const raw = {
+                symbol: 'TEST',
+                market: { price: 50 },
+                scenarios: []
+            };
+            const holdingDetails = { shares: 10 };
+            const result = normalizeConfig(raw, holdingDetails);
+            expect(result.position.shares).toBe(10);
+            expect(result.marketValue).toBe(500);
+        });
+    });
+
+    describe('buildPortfolioConfig', () => {
+        it('returns null for empty configs or zero total value', async () => {
+            global[FLAG] = true;
+            const module = await import('@pages/analysis/lab.js');
+            const { buildPortfolioConfig } = module.__analysisLabTesting;
+            expect(buildPortfolioConfig([])).toBeNull();
+
+            const zeroValueConfig = { marketValue: 0, weight: 0, scenarios: [] };
+            expect(buildPortfolioConfig([zeroValueConfig])).toBeNull();
+        });
+
+        it('builds portfolio config correctly for valid inputs', async () => {
+            global[FLAG] = true;
+            const module = await import('@pages/analysis/lab.js');
+            const { buildPortfolioConfig } = module.__analysisLabTesting;
+
+            const cfg1 = {
+                marketValue: 1000,
+                weight: 0.5,
+                scenarios: [],
+                model: { preferences: { targetCagr: 0.1, kellyScale: 0.5, benchmark: { value: 100 } } },
+                risk: { volatility: 0.2 },
+                market: { price: 100 },
+                position: { shares: 10 },
+                metrics: { outcomes: [{ id: 'base', name: 'Base', prob: 0.5, earningsCagr: 0.1 }] }
+            };
+
+            const cfg2 = {
+                marketValue: 1000,
+                weight: 0.5,
+                scenarios: [],
+                model: { preferences: { targetCagr: 0.15, kellyScale: 1.0, benchmark: { value: 150 } } },
+                risk: { volatility: 0.4 },
+                market: { price: 50 },
+                position: { shares: 20 },
+                metrics: { outcomes: [{ id: 'base', name: 'Base', prob: 0.5, earningsCagr: 0.2 }] }
+            };
+
+            const portfolio = buildPortfolioConfig([cfg1, cfg2]);
+            expect(portfolio.symbol).toBe('PORT');
+            expect(portfolio.marketValue).toBe(2000);
+            expect(portfolio.model.preferences.targetCagr).toBeCloseTo(0.125);
+            expect(portfolio.model.preferences.kellyScale).toBeCloseTo(0.75);
+        });
+    });
 });

--- a/tests/js/transactions/chart/renderers/composition.test.js
+++ b/tests/js/transactions/chart/renderers/composition.test.js
@@ -247,4 +247,18 @@ describe('drawCompositionChart', () => {
             )
         ).toBe(100);
     });
+
+    it('sets chartLayouts.composition to null on empty snapshot data', async () => {
+        const { drawCompositionChart } = await import('@js/transactions/chart/renderers/composition.js');
+        const { chartLayouts } = await import('@js/transactions/chart/state.js');
+        const { loadCompositionSnapshotData } = await import('@js/transactions/dataLoader.js');
+
+        loadCompositionSnapshotData.mockResolvedValueOnce({ valid: true, data: [] });
+
+        const ctx = { canvas: { offsetWidth: 800, offsetHeight: 600 } };
+        const chartManager = {};
+        await drawCompositionChart(ctx, chartManager, 0);
+
+        expect(chartLayouts.composition).toBeNull();
+    });
 });


### PR DESCRIPTION
Identified three key areas lacking test coverage and implemented robust unit tests.

- **`js/pages/analysis/lab.js`**: Added tests for `normalizeConfig` and `buildPortfolioConfig` logic, ensuring configurations are normalized properly and portfolio rollups function accurately.
- **`js/ambient/ambient.js`**: Replaced failing module load tests with dynamic `require` wrapped with global `window.URLSearchParams` mocks. Added branches covering maxParticle array resets and the debug condition.
- **`js/transactions/chart/renderers/composition.js`**: Added missing test branch ensuring `chartLayouts.composition` properly resets to null when provided with an empty dataset.

---
*PR created automatically by Jules for task [2176487717604776421](https://jules.google.com/task/2176487717604776421) started by @ryusoh*