### PR TITLE
🎨 Palette: Remove tabindex from layout containers

### DIFF
--- a/calendar/index.html
+++ b/calendar/index.html
@@ -160,7 +160,7 @@
         <script src="../js/ui/currencyBootstrap.js"></script>
         <div class="page-center-wrapper">
             <div class="content-block">
-                <div id="calendar-container" class="cal-heatmap-container" tabindex="0">
+                <div id="calendar-container" class="cal-heatmap-container">
                     <div id="cal-heatmap"></div>
                 </div>
             </div>

--- a/terminal/index.html
+++ b/terminal/index.html
@@ -157,7 +157,6 @@
                 id="runningAmountSection"
                 class="chart-card is-hidden"
                 aria-labelledby="runningAmountTitle"
-                tabindex="0"
             >
                 <h2 id="runningAmountTitle" class="sr-only">Running Amount Chart</h2>
                 <div class="chart-container" role="img" aria-describedby="runningAmountTitle">


### PR DESCRIPTION
🎨 Palette: Removed accessibility anti-pattern tabindex from non-interactive containers

**💡 What:** Removed the `tabindex="0"` attribute from static layout wrappers `.chart-card` and `.cal-heatmap-container` in `terminal/index.html` and `calendar/index.html`.
**🎯 Why:** Making non-interactive wrappers natively focusable creates an accessibility anti-pattern ("tab traps" or "tab bloat"). Keyboard users must unnecessarily tab through these static containers to reach actual interactive elements. 
**♿ Accessibility:** Improves keyboard navigation fluidity. Screen readers are unaffected as they already use virtual cursors to parse non-interactive structural elements perfectly fine without needing them in the `tabindex` loop.

---
*PR created automatically by Jules for task [15052484787722028615](https://jules.google.com/task/15052484787722028615) started by @ryusoh*