### PR TITLE
🎨 Palette: Add hover state to terminal table headers

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -94,3 +94,9 @@
 
 **Learning:** The application uses utility classes like `.sr-only` for screen reader accessible labels (e.g., in `terminal/index.html`). However, because the project does not use a CSS framework like Tailwind or Bootstrap, the class was missing from the CSS, causing screen-reader-only text to be visually rendered.
 **Action:** Always ensure that any utility class used for accessibility (like `.sr-only`) is explicitly defined in the project's base CSS (`css/base.css`) so that it functions correctly without relying on external frameworks.
+
+## 2026-05-21 - Disabled Interactive Elements Hover Polish (Continued)
+
+**Learning:** While the previous learning (2026-04-12) correctly identified the need for `:hover:not(:disabled)` on `.btn` elements, this rule must also be consistently applied to other interactive elements like sortable and filterable table headers. Specifically, elements with the class `.header-action-button` in the terminal table lacked proper hover states, making it difficult for users to perceive them as interactive.
+
+**Action:** Always ensure that structural interactive elements (e.g., table header sorting/filtering buttons) provide visual feedback on hover, and remember to append `:not(:disabled)` to prevent disabled buttons from showing hover effects (e.g., `.header-action-button:hover:not(:disabled) { background-color: rgba(255, 255, 255, 0.05); }`).

--- a/css/terminal/table.css
+++ b/css/terminal/table.css
@@ -145,6 +145,10 @@ th.filterable {
     border-radius: 4px;
 }
 
+.header-action-button:hover:not(:disabled) {
+    background-color: rgba(255, 255, 255, 0.05);
+}
+
 /* Ensure padding matches what TH had when it was clickable */
 #transactionTable th.sortable,
 #transactionTable th.filterable {


### PR DESCRIPTION
This PR adds a micro-UX enhancement by introducing a subtle `background-color` on hover for interactive table headers in the terminal view (`css/terminal/table.css`). The change applies only to enabled elements (`:not(:disabled)`) providing users with immediate visual feedback when interacting with sortable or filterable columns. This aligns with the "Visual Polish: Missing hover states on interactive elements" accessibility and UI feedback goals.

---
*PR created automatically by Jules for task [9322493974275792494](https://jules.google.com/task/9322493974275792494) started by @ryusoh*