### PR TITLE
Palette: Improve keyboard accessibility for calendar heatmap scrolling

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -94,3 +94,8 @@
 
 **Learning:** The application uses utility classes like `.sr-only` for screen reader accessible labels (e.g., in `terminal/index.html`). However, because the project does not use a CSS framework like Tailwind or Bootstrap, the class was missing from the CSS, causing screen-reader-only text to be visually rendered.
 **Action:** Always ensure that any utility class used for accessibility (like `.sr-only`) is explicitly defined in the project's base CSS (`css/base.css`) so that it functions correctly without relying on external frameworks.
+
+## 2026-05-16 - Data Visualization Scroll Accessibility
+
+**Learning:** Horizontally scrollable data visualization containers (like the calendar heatmap using `overflow-x: auto`) must be explicitly focusable. Otherwise, keyboard-only users cannot scroll to view off-screen data points.
+**Action:** Always add `tabindex="0"` and appropriate `:focus-visible` styling to horizontally scrollable data visualization containers.

--- a/calendar/index.html
+++ b/calendar/index.html
@@ -160,7 +160,7 @@
         <script src="../js/ui/currencyBootstrap.js"></script>
         <div class="page-center-wrapper">
             <div class="content-block">
-                <div id="calendar-container" class="cal-heatmap-container">
+                <div id="calendar-container" class="cal-heatmap-container" tabindex="0">
                     <div id="cal-heatmap"></div>
                 </div>
             </div>


### PR DESCRIPTION
**What:**
Added `tabindex="0"` to the horizontally scrollable calendar container (`.cal-heatmap-container`) in `calendar/index.html`. 
Also updated `.jules/palette.md` to document this learning.

**Why:**
Horizontally scrollable data visualization containers that use `overflow-x: auto` must be explicitly focusable so that keyboard-only users can scroll through the content using arrow keys. Without this attribute, off-screen data points are inaccessible to users relying on keyboard navigation.

**Accessibility:**
Improved keyboard navigation for data visualizations by explicitly supporting horizontal scrolling via the tab key and arrow keys. The browser's native `:focus-visible` ring provides the required visual indicator.

---
*PR created automatically by Jules for task [12752160598358382111](https://jules.google.com/task/12752160598358382111) started by @ryusoh*