### PR TITLE
Add test coverage for chart renderer early exits and PE snapshot edge cases

### DIFF
--- a/.jules/testpilot.md
+++ b/.jules/testpilot.md
@@ -65,3 +65,7 @@ Result: Tested and verified gracefull exits for zero data/series, increasing sys
 ## 2026-05-22 - Added test coverage for Chart Renderers
 - **Action:** Added Jest unit test suites for `performance.js`, `rolling.js`, and `sectors.js` chart renderers to improve overall JS test coverage.
 - **Learning:** Mocking canvas interactions and window/DOM objects early ensures smooth test execution without runtime DOM failures. Additionally, ensuring correct structure definition when mocking configuration or chart layouts allows test assertions like `.toBeDefined()` to pass correctly.
+
+## 2024-05-25 - Chart Renderer Early Exits & Snapshot Tests
+
+**Learning:** When unit testing chart renderers like `beta.js` and `fx.js`, ensure you cover the early-exit branches that handle empty data (e.g. `seriesToDraw.length === 0`). This requires mocking out internal chart dependencies like `stopPerformanceAnimation` or `stopFxAnimation` correctly. Additionally, when testing data aggregation functions like `getPESnapshotLine` that format numbers, account for asynchronous mock overrides to maintain predictable test executions and reach isolated branches.

--- a/tests/js/transactions/chart/renderers/beta.test.js
+++ b/tests/js/transactions/chart/renderers/beta.test.js
@@ -1,0 +1,69 @@
+import { jest } from '@jest/globals';
+
+jest.mock('@js/transactions/state.js', () => ({
+    transactionState: {
+        chartDateRange: { from: null, to: null },
+        chartVisibility: {},
+    },
+}));
+
+jest.mock('@js/transactions/chart/state.js', () => ({
+    chartLayouts: {},
+    legendState: { performanceDirty: false },
+}));
+
+jest.mock('@js/transactions/chart/core.js', () => ({
+    drawAxes: jest.fn(),
+    drawMountainFill: jest.fn(),
+    drawEndValue: jest.fn(),
+}));
+
+jest.mock('@js/transactions/chart/animation.js', () => ({
+    advancePerformanceAnimation: jest.fn(),
+    isAnimationEnabled: jest.fn(() => false),
+    stopPerformanceAnimation: jest.fn(),
+    schedulePerformanceAnimation: jest.fn(),
+    stopContributionAnimation: jest.fn(),
+    stopFxAnimation: jest.fn(),
+    stopPeAnimation: jest.fn(),
+    stopConcentrationAnimation: jest.fn(),
+    drawSeriesGlow: jest.fn(),
+}));
+
+jest.mock('@js/transactions/chart/interaction.js', () => ({
+    updateCrosshairUI: jest.fn(),
+    updateLegend: jest.fn(),
+    drawCrosshairOverlay: jest.fn(),
+}));
+
+jest.mock('@js/config.js', () => ({
+    mountainFill: { enabled: false },
+    CHART_LINE_WIDTHS: { performance: 2 },
+}));
+
+jest.mock('@js/transactions/utils.js', () => ({
+    getShowChartLabels: jest.fn(() => true),
+}));
+
+jest.mock('@js/transactions/chart/helpers.js', () => ({
+    parseLocalDate: jest.fn((d) => new Date(d)),
+    clampTime: jest.fn((v, min, max) => Math.max(min, Math.min(max, v))),
+    createTimeInterpolator: jest.fn(() => jest.fn()),
+}));
+
+describe('drawBetaChart', () => {
+    it('gracefully exits when there are no series to draw', async () => {
+        const { drawBetaChart } = await import('@js/transactions/chart/renderers/beta.js');
+        const { stopContributionAnimation } = await import('@js/transactions/chart/animation.js');
+        const { chartLayouts } = await import('@js/transactions/chart/state.js');
+
+        const mockCtx = {
+            canvas: { offsetWidth: 800, offsetHeight: 400 },
+        };
+
+        drawBetaChart(mockCtx, {}, 0);
+
+        expect(stopContributionAnimation).toHaveBeenCalled();
+        expect(chartLayouts.beta).toBeNull();
+    });
+});

--- a/tests/js/transactions/chart/renderers/fx.test.js
+++ b/tests/js/transactions/chart/renderers/fx.test.js
@@ -1,0 +1,78 @@
+import { jest } from '@jest/globals';
+
+jest.mock('@js/transactions/state.js', () => ({
+    transactionState: {
+        chartDateRange: { from: null, to: null },
+        chartVisibility: {},
+        selectedCurrency: 'USD',
+    },
+}));
+
+jest.mock('@js/transactions/chart/state.js', () => ({
+    chartLayouts: {},
+    legendState: { fxDirty: false },
+}));
+
+jest.mock('@js/transactions/chart/core.js', () => ({
+    drawAxes: jest.fn(),
+    drawMountainFill: jest.fn(),
+    drawEndValue: jest.fn(),
+}));
+
+jest.mock('@js/transactions/chart/animation.js', () => ({
+    advanceFxAnimation: jest.fn(),
+    isAnimationEnabled: jest.fn(() => false),
+    stopFxAnimation: jest.fn(),
+    scheduleFxAnimation: jest.fn(),
+    stopPerformanceAnimation: jest.fn(),
+    stopContributionAnimation: jest.fn(),
+    stopPeAnimation: jest.fn(),
+    stopConcentrationAnimation: jest.fn(),
+    drawSeriesGlow: jest.fn(),
+}));
+
+jest.mock('@js/transactions/chart/interaction.js', () => ({
+    updateCrosshairUI: jest.fn(),
+    updateLegend: jest.fn(),
+    drawCrosshairOverlay: jest.fn(),
+}));
+
+jest.mock('@js/config.js', () => ({
+    mountainFill: { enabled: false },
+    CHART_LINE_WIDTHS: { fx: 2 },
+}));
+
+jest.mock('@js/transactions/utils.js', () => ({
+    getShowChartLabels: jest.fn(() => true),
+    formatPercentInline: jest.fn(v => `${v}%`),
+    formatFxValue: jest.fn(v => v.toString()),
+}));
+
+jest.mock('@js/utils/smoothing.js', () => ({
+    getSmoothingConfig: jest.fn(() => null),
+    smoothFinancialData: jest.fn(points => points),
+}));
+
+jest.mock('@js/transactions/chart/helpers.js', () => ({
+    parseLocalDate: jest.fn((d) => new Date(d)),
+    clampTime: jest.fn((v, min, max) => Math.max(min, Math.min(max, v))),
+    createTimeInterpolator: jest.fn(() => jest.fn()),
+    computePercentTickInfo: jest.fn(() => ({ startTick: 0, endTick: 10, tickSpacing: 2 })),
+}));
+
+describe('drawFxChart', () => {
+    it('gracefully exits when there are no series to draw', async () => {
+        const { drawFxChart } = await import('@js/transactions/chart/renderers/fx.js');
+        const { stopFxAnimation } = await import('@js/transactions/chart/animation.js');
+        const { chartLayouts } = await import('@js/transactions/chart/state.js');
+
+        const mockCtx = {
+            canvas: { offsetWidth: 800, offsetHeight: 400 },
+        };
+
+        drawFxChart(mockCtx, {}, 0);
+
+        expect(stopFxAnimation).toHaveBeenCalled();
+        expect(chartLayouts.fx).toBeNull();
+    });
+});

--- a/tests/js/transactions/terminal/snapshots.test.js
+++ b/tests/js/transactions/terminal/snapshots.test.js
@@ -88,3 +88,89 @@ describe('snapshots.js', () => {
         });
     });
 });
+
+describe('getPESnapshotLine', () => {
+    let getPESnapshotLine;
+    let loadPEData;
+
+    beforeEach(async () => {
+        jest.resetModules();
+        jest.mock('@js/transactions/chart/renderers/pe.js', () => ({
+            loadPEData: jest.fn(),
+            buildPESeries: jest.fn(),
+        }));
+        jest.mock('@js/transactions/state.js', () => ({
+            transactionState: { chartDateRange: { from: null, to: null } },
+        }));
+        jest.mock('@js/transactions/chart/helpers.js', () => ({
+            parseLocalDate: jest.fn((dateStr) => new Date(dateStr)),
+        }));
+
+        loadPEData = (await import('@js/transactions/chart/renderers/pe.js')).loadPEData;
+        const { buildPESeries } = await import('@js/transactions/chart/renderers/pe.js');
+
+        buildPESeries.mockImplementation((dates, portfolioPEs, tickerPEs, weights, from, to) => {
+            const result = [];
+            for (let i = 0; i < dates.length; i++) {
+                const dateObj = new Date(dates[i]);
+                if ((!from || dateObj >= from) && (!to || dateObj <= to)) {
+                    result.push({
+                        pe: portfolioPEs[i],
+                        tickerPEs: tickerPEs ? tickerPEs[dates[i]] : null,
+                        tickerWeights: weights ? weights[dates[i]] : null,
+                    });
+                }
+            }
+            return result;
+        });
+
+        getPESnapshotLine = (await import('@js/transactions/terminal/snapshots.js')).getPESnapshotLine;
+    });
+
+    it('returns null when loadPEData returns invalid data', async () => {
+        loadPEData.mockResolvedValue(null);
+        let result = await getPESnapshotLine();
+        expect(result).toBeNull();
+
+        loadPEData.mockResolvedValue({});
+        result = await getPESnapshotLine();
+        expect(result).toBeNull();
+
+        loadPEData.mockResolvedValue({ dates: [] });
+        result = await getPESnapshotLine();
+        expect(result).toBeNull();
+    });
+
+    it('returns "No PE data in range" when series is empty', async () => {
+        loadPEData.mockResolvedValue({ dates: ['2024-01-01'], portfolio_pe: [15] });
+        const { transactionState } = await import('@js/transactions/state.js');
+        transactionState.chartDateRange = { from: '2025-01-01', to: '2025-02-01' };
+
+        const result = await getPESnapshotLine();
+        expect(result).toBe('No PE data in range');
+    });
+
+    it('returns formatted text with forward PE and components', async () => {
+        loadPEData.mockResolvedValue({
+            dates: ['2024-01-01', '2024-02-01'],
+            portfolio_pe: [15, 20],
+            ticker_pe: {
+                '2024-02-01': { AAPL: 25, MSFT: 30, VT: 18 }
+            },
+            ticker_weights: {
+                '2024-02-01': { AAPL: 0.5, MSFT: 0.3, VT: 0.2 }
+            },
+            forward_pe: {
+                ticker_forward_pe: { AAPL: 20, MSFT: 28 },
+                msci_pe_ratio: { ratio: 1.2 }
+            }
+        });
+
+        const result = await getPESnapshotLine();
+        expect(result).toContain('Current: 20.00x | Range: 15.00x - 20.00x');
+        expect(result).toContain('Components:');
+        expect(result).toContain('AAPL:25/20');
+        expect(result).toContain('MSFT:30/28');
+        expect(result).toContain('VT:18/15'); // 18 / 1.2 = 15
+    });
+});


### PR DESCRIPTION
This PR increases frontend unit test coverage by targeting specific early-exit branches within the transaction charting logic, ensuring greater reliability when the application handles empty or invalid datasets.

### Changes
*   Added `tests/js/transactions/chart/renderers/beta.test.js` to ensure `drawBetaChart` gracefully bails out and clears animation state when no valid series data exists.
*   Added `tests/js/transactions/chart/renderers/fx.test.js` to verify identical early-exit behavior within `drawFxChart`.
*   Expanded `tests/js/transactions/terminal/snapshots.test.js` with comprehensive checks for `getPESnapshotLine`, asserting proper fallback handling when asynchronous `loadPEData` responses are invalid, missing, or empty. 
*   Updated `.jules/testpilot.md` journal with learning regarding chart renderer mocks and asynchronous snapshots.

All modifications strictly conform to the `TestPilot` directive boundaries. No production logic was altered; changes exclusively add isolated automated test assertions and journal documentation. `pnpm run verify:all` execution confirms the test suite remains stable while elevating coverage percentage.

---
*PR created automatically by Jules for task [3106948405122851828](https://jules.google.com/task/3106948405122851828) started by @ryusoh*