### PR TITLE
🎨 Palette: Add native title tooltips to icon-only controls

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -99,3 +99,6 @@
 
 **Learning:** Horizontally scrollable data visualization containers (like the calendar heatmap using `overflow-x: auto`) must be explicitly focusable. Otherwise, keyboard-only users cannot scroll to view off-screen data points.
 **Action:** Always add `tabindex="0"` and appropriate `:focus-visible` styling to horizontally scrollable data visualization containers.
+## 2026-05-25 - Title Tooltips for Icon-Only Buttons
+**Learning:** While `aria-label` makes icon-only buttons accessible to screen readers, sighted users might still struggle to understand their purpose without hover feedback.
+**Action:** Always pair `aria-label` with a native `title` attribute for icon-only interactive elements to provide a helpful browser tooltip.

--- a/calendar/index.html
+++ b/calendar/index.html
@@ -102,22 +102,22 @@
         <nav class="container" aria-label="Main Navigation">
             <ul>
                 <li>
-                    <a href="../" aria-label="Main Site">
+                    <a href="../" aria-label="Main Site" title="Main Site">
                         <i class="fa fa-chevron-right" aria-hidden="true"></i>
                     </a>
                 </li>
                 <li>
-                    <a href="../position/" aria-label="Position">
+                    <a href="../position/" aria-label="Position" title="Position">
                         <i class="fa fa-pie-chart" aria-hidden="true"></i>
                     </a>
                 </li>
                 <li>
-                    <a href="./" aria-label="Calendar">
+                    <a href="./" aria-label="Calendar" title="Calendar">
                         <i class="fa fa-calendar" aria-hidden="true"></i>
                     </a>
                 </li>
                 <li class="hide-on-mobile">
-                    <a href="../terminal/" aria-label="Terminal">
+                    <a href="../terminal/" aria-label="Terminal" title="Terminal">
                         <i class="fa fa-code" aria-hidden="true"></i>
                     </a>
                 </li>
@@ -127,7 +127,7 @@
             <button
                 class="currency-toggle active"
                 data-currency="USD"
-                aria-label="US Dollar"
+                aria-label="US Dollar" title="US Dollar"
                 aria-pressed="true"
             >
                 $
@@ -135,7 +135,7 @@
             <button
                 class="currency-toggle"
                 data-currency="CNY"
-                aria-label="Chinese Yuan"
+                aria-label="Chinese Yuan" title="Chinese Yuan"
                 aria-pressed="false"
             >
                 ¥
@@ -143,7 +143,7 @@
             <button
                 class="currency-toggle"
                 data-currency="JPY"
-                aria-label="Japanese Yen"
+                aria-label="Japanese Yen" title="Japanese Yen"
                 aria-pressed="false"
             >
                 ¥
@@ -151,7 +151,7 @@
             <button
                 class="currency-toggle"
                 data-currency="KRW"
-                aria-label="South Korean Won"
+                aria-label="South Korean Won" title="South Korean Won"
                 aria-pressed="false"
             >
                 ₩
@@ -165,13 +165,13 @@
                 </div>
             </div>
             <div id="calendar-navigation-controls">
-                <button id="cal-prev" class="cal-nav-btn" aria-label="Previous Month">
+                <button id="cal-prev" class="cal-nav-btn" aria-label="Previous Month" title="Previous Month">
                     <i class="fa fa-chevron-left" aria-hidden="true"></i>
                 </button>
-                <button id="cal-today" class="cal-nav-btn" aria-label="Go to Today">
+                <button id="cal-today" class="cal-nav-btn" aria-label="Go to Today" title="Go to Today">
                     <i class="fa fa-circle-o" aria-hidden="true"></i>
                 </button>
-                <button id="cal-next" class="cal-nav-btn" aria-label="Next Month">
+                <button id="cal-next" class="cal-nav-btn" aria-label="Next Month" title="Next Month">
                     <i class="fa fa-chevron-right" aria-hidden="true"></i>
                 </button>
             </div>
@@ -182,7 +182,7 @@
                 href="https://github.com/ryusoh"
                 target="_blank"
                 rel="noopener noreferrer"
-                aria-label="GitHub Profile"
+                aria-label="GitHub Profile" title="GitHub Profile"
                 ><i class="fa fa-github" style="color: #aaa; opacity: 0.5" aria-hidden="true"></i
             ></a>
         </footer>

--- a/index.html
+++ b/index.html
@@ -74,22 +74,22 @@
         <nav class="container" aria-label="Main Navigation">
             <ul>
                 <li>
-                    <a href="https://www.lyeutsaon.com/" class="nav-link" aria-label="Main Site">
+                    <a href="https://www.lyeutsaon.com/" class="nav-link" aria-label="Main Site" title="Main Site">
                         <i class="fa fa-chevron-right" aria-hidden="true"></i>
                     </a>
                 </li>
                 <li>
-                    <a href="./position" class="nav-link" aria-label="Position"
+                    <a href="./position" class="nav-link" aria-label="Position" title="Position"
                         ><i class="fa fa-pie-chart" aria-hidden="true"></i
                     ></a>
                 </li>
                 <li>
-                    <a href="./calendar" class="nav-link" aria-label="Calendar"
+                    <a href="./calendar" class="nav-link" aria-label="Calendar" title="Calendar"
                         ><i class="fa fa-calendar" aria-hidden="true"></i
                     ></a>
                 </li>
                 <li class="hide-on-mobile">
-                    <a href="./terminal" class="nav-link" aria-label="Terminal"
+                    <a href="./terminal" class="nav-link" aria-label="Terminal" title="Terminal"
                         ><i class="fa fa-code" aria-hidden="true"></i
                     ></a>
                 </li>
@@ -122,7 +122,7 @@
                 href="https://github.com/ryusoh"
                 target="_blank"
                 rel="noopener noreferrer"
-                aria-label="GitHub Profile"
+                aria-label="GitHub Profile" title="GitHub Profile"
             >
                 <i class="fa fa-github" style="color: #aaa; opacity: 0.5" aria-hidden="true"></i>
             </a>

--- a/position/index.html
+++ b/position/index.html
@@ -79,22 +79,22 @@
         <nav class="container" aria-label="Main Navigation">
             <ul>
                 <li>
-                    <a href="../" aria-label="Main Site">
+                    <a href="../" aria-label="Main Site" title="Main Site">
                         <i class="fa fa-chevron-right" aria-hidden="true"></i>
                     </a>
                 </li>
                 <li>
-                    <a href="../position/" aria-label="Position">
+                    <a href="../position/" aria-label="Position" title="Position">
                         <i class="fa fa-pie-chart" aria-hidden="true"></i>
                     </a>
                 </li>
                 <li>
-                    <a href="../calendar/" aria-label="Calendar">
+                    <a href="../calendar/" aria-label="Calendar" title="Calendar">
                         <i class="fa fa-calendar" aria-hidden="true"></i>
                     </a>
                 </li>
                 <li class="hide-on-mobile">
-                    <a href="../terminal/" aria-label="Terminal">
+                    <a href="../terminal/" aria-label="Terminal" title="Terminal">
                         <i class="fa fa-code" aria-hidden="true"></i>
                     </a>
                 </li>
@@ -110,7 +110,7 @@
                 <button
                     class="currency-toggle active"
                     data-currency="USD"
-                    aria-label="US Dollar"
+                    aria-label="US Dollar" title="US Dollar"
                     aria-pressed="true"
                 >
                     $
@@ -118,7 +118,7 @@
                 <button
                     class="currency-toggle"
                     data-currency="CNY"
-                    aria-label="Chinese Yuan"
+                    aria-label="Chinese Yuan" title="Chinese Yuan"
                     aria-pressed="false"
                 >
                     ¥
@@ -126,7 +126,7 @@
                 <button
                     class="currency-toggle"
                     data-currency="JPY"
-                    aria-label="Japanese Yen"
+                    aria-label="Japanese Yen" title="Japanese Yen"
                     aria-pressed="false"
                 >
                     ¥
@@ -134,7 +134,7 @@
                 <button
                     class="currency-toggle"
                     data-currency="KRW"
-                    aria-label="South Korean Won"
+                    aria-label="South Korean Won" title="South Korean Won"
                     aria-pressed="false"
                 >
                     ₩
@@ -177,7 +177,7 @@
                 href="https://github.com/ryusoh"
                 target="_blank"
                 rel="noopener noreferrer"
-                aria-label="GitHub Profile"
+                aria-label="GitHub Profile" title="GitHub Profile"
                 ><i class="fa fa-github" style="color: #aaa; opacity: 0.5" aria-hidden="true"></i
             ></a>
         </footer>

--- a/terminal/index.html
+++ b/terminal/index.html
@@ -73,22 +73,22 @@
         <nav class="nav-container" aria-label="Main Navigation">
             <ul>
                 <li>
-                    <a href="../" aria-label="Main Site">
+                    <a href="../" aria-label="Main Site" title="Main Site">
                         <i class="fa fa-chevron-right" aria-hidden="true"></i>
                     </a>
                 </li>
                 <li>
-                    <a href="../position/" aria-label="Position">
+                    <a href="../position/" aria-label="Position" title="Position">
                         <i class="fa fa-pie-chart" aria-hidden="true"></i>
                     </a>
                 </li>
                 <li>
-                    <a href="../calendar/" aria-label="Calendar">
+                    <a href="../calendar/" aria-label="Calendar" title="Calendar">
                         <i class="fa fa-calendar" aria-hidden="true"></i>
                     </a>
                 </li>
                 <li>
-                    <a href="./" aria-label="Terminal">
+                    <a href="./" aria-label="Terminal" title="Terminal">
                         <i class="fa fa-code" aria-hidden="true"></i>
                     </a>
                 </li>
@@ -98,7 +98,7 @@
             <button
                 class="currency-toggle active"
                 data-currency="USD"
-                aria-label="US Dollar"
+                aria-label="US Dollar" title="US Dollar"
                 aria-pressed="true"
             >
                 $
@@ -106,7 +106,7 @@
             <button
                 class="currency-toggle"
                 data-currency="CNY"
-                aria-label="Chinese Yuan"
+                aria-label="Chinese Yuan" title="Chinese Yuan"
                 aria-pressed="false"
             >
                 ¥
@@ -114,7 +114,7 @@
             <button
                 class="currency-toggle"
                 data-currency="JPY"
-                aria-label="Japanese Yen"
+                aria-label="Japanese Yen" title="Japanese Yen"
                 aria-pressed="false"
             >
                 ¥
@@ -122,7 +122,7 @@
             <button
                 class="currency-toggle"
                 data-currency="KRW"
-                aria-label="South Korean Won"
+                aria-label="South Korean Won" title="South Korean Won"
                 aria-pressed="false"
             >
                 ₩
@@ -178,7 +178,7 @@
                                 <button
                                     type="button"
                                     class="header-action-button"
-                                    aria-label="Sort by Date"
+                                    aria-label="Sort by Date" title="Sort by Date"
                                 >
                                     Date<span class="sort-indicator"></span>
                                 </button>
@@ -187,7 +187,7 @@
                                 <button
                                     type="button"
                                     class="header-action-button"
-                                    aria-label="Filter by Type"
+                                    aria-label="Filter by Type" title="Filter by Type"
                                 >
                                     Type
                                     <span class="filter-indicator">
@@ -199,14 +199,14 @@
                                 <button
                                     type="button"
                                     class="header-action-button"
-                                    aria-label="Sort by Security"
+                                    aria-label="Sort by Security" title="Sort by Security"
                                 >
                                     Security<span class="sort-indicator"></span>
                                 </button>
                                 <button
                                     type="button"
                                     class="filter-indicator header-action-button"
-                                    aria-label="Filter by Security"
+                                    aria-label="Filter by Security" title="Filter by Security"
                                 >
                                     <i class="fa fa-filter" aria-hidden="true"></i>
                                 </button>
@@ -215,7 +215,7 @@
                                 <button
                                     type="button"
                                     class="header-action-button"
-                                    aria-label="Sort by Quantity"
+                                    aria-label="Sort by Quantity" title="Sort by Quantity"
                                 >
                                     Quantity<span class="sort-indicator"></span>
                                 </button>
@@ -224,7 +224,7 @@
                                 <button
                                     type="button"
                                     class="header-action-button"
-                                    aria-label="Sort by Price"
+                                    aria-label="Sort by Price" title="Sort by Price"
                                 >
                                     Price<span class="sort-indicator"></span>
                                 </button>
@@ -233,7 +233,7 @@
                                 <button
                                     type="button"
                                     class="header-action-button"
-                                    aria-label="Sort by Amount"
+                                    aria-label="Sort by Amount" title="Sort by Amount"
                                 >
                                     Amount<span class="sort-indicator"></span>
                                 </button>
@@ -259,7 +259,7 @@
                 href="https://github.com/ryusoh"
                 target="_blank"
                 rel="noopener noreferrer"
-                aria-label="GitHub Profile"
+                aria-label="GitHub Profile" title="GitHub Profile"
                 ><i class="fa fa-github" style="color: #aaa; opacity: 0.5" aria-hidden="true"></i
             ></a>
         </footer>


### PR DESCRIPTION
🎨 Palette: Add native title tooltips to icon-only controls

💡 What: Added `title` attributes matching the existing `aria-label` text to all icon-only navigation links, currency toggles, calendar control buttons, and terminal filter/sort buttons.
🎯 Why: While `aria-label` makes these controls accessible to screen readers, sighted users often rely on hover tooltips to understand the purpose of ambiguous icons.
♿ Accessibility: Improves accessibility for users who rely on visual hover feedback and those using mouse/pointer devices without screen readers.

---
*PR created automatically by Jules for task [6358960939506722987](https://jules.google.com/task/6358960939506722987) started by @ryusoh*