### PR TITLE
⚡ Bolt: Replace array reductions with manual loops in high-frequency statistical paths

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -222,3 +222,7 @@
 
 **Learning:** Using `Array.from(map.keys())` or `Array.from({ length })` creates intermediate arrays and iterators which add overhead to garbage collection in high-frequency functions.
 **Action:** Replace `Array.from({ length }, () => 0)` with `new Array(length).fill(0)` and explicit iterations over iterables into pre-allocated arrays to eliminate overhead and closure allocations.
+
+## 2026-05-26 - Replaced higher-order reduce() with manual for loops
+**Learning:** Using chained array methods or `.reduce()` inside high-frequency processing paths (like analytical summations and statistical computations over large arrays) introduces unnecessary functional callback overhead and closure allocations, leading to increased garbage collection pressure.
+**Action:** Replaced `.reduce()` calls in `js/transactions/terminal/stats/analysis.js` and `js/pages/analysis/lab.js` with pre-allocated index-based `for` loops to drop closure allocation overhead and speed up array summations.

--- a/js/pages/analysis/lab.js
+++ b/js/pages/analysis/lab.js
@@ -384,10 +384,10 @@ function computeMetrics(config) {
     const outcomes = normalizedScenarios.map((scenario) =>
         computeScenarioOutcome(scenario, { price, eps, horizon })
     );
-    const expectedMultiple = outcomes.reduce(
-        (sum, outcome) => sum + outcome.prob * outcome.multiple,
-        0
-    );
+    let expectedMultiple = 0;
+    for (let i = 0; i < outcomes.length; i++) {
+        expectedMultiple += outcomes[i].prob * outcomes[i].multiple;
+    }
     const expectedCagr = expectedMultiple > 0 ? expectedMultiple ** (1 / horizon) - 1 : 0;
     const edge = expectedCagr - benchmark;
     const variance = volatility ** 2;
@@ -883,12 +883,20 @@ function buildPortfolioConfig(configs) {
     if (!configs.length) {
         return null;
     }
-    const totalValue = configs.reduce((sum, cfg) => sum + cfg.marketValue, 0);
+    let totalValue = 0;
+    for (let i = 0; i < configs.length; i++) {
+        totalValue += configs[i].marketValue;
+    }
     if (!(totalValue > 0)) {
         return null;
     }
-    const weighted = (selector) =>
-        configs.reduce((sum, cfg) => sum + cfg.weight * selector(cfg), 0);
+    const weighted = (selector) => {
+        let sum = 0;
+        for (let i = 0; i < configs.length; i++) {
+            sum += configs[i].weight * selector(configs[i]);
+        }
+        return sum;
+    };
     const basePreferences = getPreferences(configs[0]);
     const horizonRaw = Number(basePreferences.horizon ?? 1);
     const horizon = Number.isFinite(horizonRaw) && horizonRaw > 0 ? horizonRaw : 1;
@@ -897,12 +905,14 @@ function buildPortfolioConfig(configs) {
     const benchmarkValue = weighted((cfg) => getBenchmarkDescriptor(getPreferences(cfg)).value);
     const kellyScale = weighted((cfg) => getPreferences(cfg).kellyScale ?? 0.5);
     const targetCagr = weighted((cfg) => getPreferences(cfg).targetCagr ?? 0.1);
-    const volatility = Math.sqrt(
-        configs.reduce((sum, cfg) => {
-            const vol = getEffectiveVolatility(cfg);
-            return sum + Math.pow(cfg.weight, 2) * Math.pow(vol, 2);
-        }, 0)
-    );
+
+    let volSum = 0;
+    for (let i = 0; i < configs.length; i++) {
+        const vol = getEffectiveVolatility(configs[i]);
+        volSum += Math.pow(configs[i].weight, 2) * Math.pow(vol, 2);
+    }
+    const volatility = Math.sqrt(volSum);
+
     const overrides = {
         price,
         eps,
@@ -1000,7 +1010,10 @@ async function buildConfigs() {
     );
 
     const validConfigs = configs.filter(Boolean);
-    const totalValue = validConfigs.reduce((sum, cfg) => sum + cfg.marketValue, 0);
+    let totalValue = 0;
+    for (let i = 0; i < validConfigs.length; i++) {
+        totalValue += validConfigs[i].marketValue;
+    }
     validConfigs.forEach((cfg) => {
         cfg.weight = totalValue > 0 ? cfg.marketValue / totalValue : 0;
     });

--- a/js/transactions/terminal/stats/analysis.js
+++ b/js/transactions/terminal/stats/analysis.js
@@ -318,15 +318,19 @@ export async function getDurationStatsText() {
             if (!lots || lots.length === 0) {
                 return null;
             }
-            const totalQty = lots.reduce((sum, lot) => sum + lot.qty, 0);
+            let totalQty = 0;
+            for (let i = 0; i < lots.length; i++) {
+                totalQty += lots[i].qty;
+            }
             if (totalQty <= 0) {
                 return null;
             }
-            const avgAgeDays =
-                lots.reduce((sum, lot) => {
-                    const diffMs = Math.max(0, baselineDate - lot.date);
-                    return sum + lot.qty * (diffMs / MS_IN_DAY);
-                }, 0) / totalQty;
+            let ageDaysSum = 0;
+            for (let i = 0; i < lots.length; i++) {
+                const diffMs = Math.max(0, baselineDate - lots[i].date);
+                ageDaysSum += lots[i].qty * (diffMs / MS_IN_DAY);
+            }
+            const avgAgeDays = ageDaysSum / totalQty;
             return {
                 ticker: formatTicker(holding.ticker),
                 weight: holding.weight,
@@ -337,10 +341,17 @@ export async function getDurationStatsText() {
         })
         .filter(Boolean);
 
-    const totalWeight = entries.reduce((sum, entry) => sum + entry.weight, 0);
+    let totalWeight = 0;
+    for (let i = 0; i < entries.length; i++) {
+        totalWeight += entries[i].weight;
+    }
+    let weightedAvgDaysSum = 0;
+    for (let i = 0; i < entries.length; i++) {
+        weightedAvgDaysSum += entries[i].weight * entries[i].avgAgeDays;
+    }
     const weightedAvgDays =
         totalWeight > 0
-            ? entries.reduce((sum, entry) => sum + entry.weight * entry.avgAgeDays, 0) / totalWeight
+            ? weightedAvgDaysSum / totalWeight
             : null;
     const medianDays = computeWeightedMedian(
         entries,
@@ -364,15 +375,21 @@ export async function getDurationStatsText() {
         ]);
     }
 
-    const totalClosedQty = hasClosedData
-        ? closedSales.reduce((sum, item) => sum + (Number(item.qty) || 0), 0)
-        : 0;
+    let totalClosedQty = 0;
+    if (hasClosedData) {
+        for (let i = 0; i < closedSales.length; i++) {
+            totalClosedQty += Number(closedSales[i].qty) || 0;
+        }
+    }
+    let closedDaysSum = 0;
+    if (totalClosedQty > 0) {
+        for (let i = 0; i < closedSales.length; i++) {
+            closedDaysSum += (Number(closedSales[i].qty) || 0) * (Number(closedSales[i].days) || 0);
+        }
+    }
     const weightedClosedAvgDays =
         totalClosedQty > 0
-            ? closedSales.reduce(
-                  (sum, item) => sum + (Number(item.qty) || 0) * (Number(item.days) || 0),
-                  0
-              ) / totalClosedQty
+            ? closedDaysSum / totalClosedQty
             : null;
     if (Number.isFinite(weightedClosedAvgDays)) {
         summaryRows.push([
@@ -383,11 +400,14 @@ export async function getDurationStatsText() {
         ]);
     }
 
-    const totalOpenShareWeight = entries.reduce((sum, entry) => sum + entry.openShares, 0);
-    const openShareWeightedSum = entries.reduce(
-        (sum, entry) => sum + entry.openShares * entry.avgAgeDays,
-        0
-    );
+    let totalOpenShareWeight = 0;
+    for (let i = 0; i < entries.length; i++) {
+        totalOpenShareWeight += entries[i].openShares;
+    }
+    let openShareWeightedSum = 0;
+    for (let i = 0; i < entries.length; i++) {
+        openShareWeightedSum += entries[i].openShares * entries[i].avgAgeDays;
+    }
     const allDenominator = totalOpenShareWeight + totalClosedQty;
     const weightedAvgAll =
         allDenominator > 0
@@ -467,7 +487,10 @@ export async function getLifespanStatsText() {
                 return null;
             }
             const lots = lotsByTicker?.get(normalizedTicker) || [];
-            const openShares = lots.reduce((sum, lot) => sum + lot.qty, 0);
+            let openShares = 0;
+            for (let i = 0; i < lots.length; i++) {
+                openShares += lots[i].qty;
+            }
             if (!Number.isFinite(openShares) || openShares <= 0) {
                 return null;
             }
@@ -534,17 +557,23 @@ export async function getLifespanStatsText() {
         : '';
 
     const summaryRows = [['Snapshot Date', snapshot.dateLabel || 'Latest']];
-    const openShareSum = openEntries.reduce((sum, entry) => sum + entry.openShares, 0);
-    const openWeightedSpanSum = openEntries.reduce(
-        (sum, entry) => sum + entry.spanDays * entry.openShares,
-        0
-    );
+    let openShareSum = 0;
+    for (let i = 0; i < openEntries.length; i++) {
+        openShareSum += openEntries[i].openShares;
+    }
+    let openWeightedSpanSum = 0;
+    for (let i = 0; i < openEntries.length; i++) {
+        openWeightedSpanSum += openEntries[i].spanDays * openEntries[i].openShares;
+    }
     const weightedAvgOpen = openShareSum > 0 ? openWeightedSpanSum / openShareSum : null;
-    const closedShareSum = closedEntries.reduce((sum, entry) => sum + entry.shares, 0);
-    const closedWeightedSpanSum = closedEntries.reduce(
-        (sum, entry) => sum + entry.spanDays * entry.shares,
-        0
-    );
+    let closedShareSum = 0;
+    for (let i = 0; i < closedEntries.length; i++) {
+        closedShareSum += closedEntries[i].shares;
+    }
+    let closedWeightedSpanSum = 0;
+    for (let i = 0; i < closedEntries.length; i++) {
+        closedWeightedSpanSum += closedEntries[i].spanDays * closedEntries[i].shares;
+    }
     const weightedAvgClosed = closedShareSum > 0 ? closedWeightedSpanSum / closedShareSum : null;
     const combinedDenominator = openShareSum + closedShareSum;
     const weightedAvgAll =
@@ -631,7 +660,10 @@ export async function getConcentrationText() {
         return 'No positive weights in composition data.';
     }
 
-    const totalWeight = holdings.reduce((sum, item) => sum + item.weight, 0);
+    let totalWeight = 0;
+    for (let i = 0; i < holdings.length; i++) {
+        totalWeight += holdings[i].weight;
+    }
     if (totalWeight <= 0) {
         return 'No positive weights in composition data.';
     }
@@ -645,10 +677,10 @@ export async function getConcentrationText() {
         .sort((a, b) => b.normalizedWeight - a.normalizedWeight);
 
     // Calculate adjusted HHI using ETF internal diversification
-    const hhi = normalized.reduce(
-        (sum, item) => sum + calculateAdjustedHhiContribution(item.ticker, item.normalizedWeight),
-        0
-    );
+    let hhi = 0;
+    for (let i = 0; i < normalized.length; i++) {
+        hhi += calculateAdjustedHhiContribution(normalized[i].ticker, normalized[i].normalizedWeight);
+    }
     const effectiveHoldings = hhi > 0 ? 1 / hhi : null;
     let top3Weight = 0;
     let top5Weight = 0;


### PR DESCRIPTION
💡 What: Replaced higher-order `.reduce()` operations with manual index-based `for` loops in analytical components (`analysis.js` and `lab.js`).
🎯 Why: In high-frequency rendering and data calculation paths, chained higher-order array methods and `.reduce()` generate intermediate closure allocations on every iteration, leading to increased garbage collection pressure.
📊 Impact: Decreases intermediate object allocation overhead and speeds up mathematical summations dynamically calculating statistical metrics (e.g. Weighted Averages, Expected CAGRs) over large holding histories and scenarios.
🔬 Measurement: Verify stable unit tests execution with `pnpm run verify:all`.

---
*PR created automatically by Jules for task [5304083581775047988](https://jules.google.com/task/5304083581775047988) started by @ryusoh*