### PR TITLE
test: add unit tests for chart helpers, table parser, terminal transaction handler, and contribution data

### DIFF
--- a/tests/js/transactions/chart/data/contribution.test.js
+++ b/tests/js/transactions/chart/data/contribution.test.js
@@ -1,0 +1,79 @@
+import { computeAppreciationSeries } from '../../../../../js/transactions/chart/data/contribution.js';
+
+describe('Contribution Data Helpers', () => {
+    describe('computeAppreciationSeries', () => {
+        it('should calculate appreciation correctly when lengths match', () => {
+            const balanceData = [
+                { date: new Date('2024-01-01'), value: 100 },
+                { date: new Date('2024-01-02'), value: 120 },
+                { date: new Date('2024-01-03'), value: 150 }
+            ];
+            const contributionData = [
+                { date: new Date('2024-01-01'), amount: 100 },
+                { date: new Date('2024-01-02'), amount: 110 },
+                { date: new Date('2024-01-03'), amount: 130 }
+            ];
+
+            const result = computeAppreciationSeries(balanceData, contributionData);
+
+            expect(result.length).toBe(3);
+            expect(result[0].value).toBe(0); // 100 - 100
+            expect(result[1].value).toBe(10); // 120 - 110
+            expect(result[2].value).toBe(20); // 150 - 130
+            expect(result[0].date).toBe(balanceData[0].date);
+        });
+
+        it('should handle empty arrays', () => {
+            expect(computeAppreciationSeries([], [])).toEqual([]);
+            expect(computeAppreciationSeries(null, null)).toEqual([]);
+        });
+
+        it('should align data by date if lengths do not match using interpolation', () => {
+            const balanceData = [
+                { date: new Date('2024-01-01'), value: 100 },
+                { date: new Date('2024-01-02'), value: 120 },
+                { date: new Date('2024-01-04'), value: 150 }
+            ];
+            const contributionData = [
+                { date: new Date('2024-01-01'), amount: 100 },
+                { date: new Date('2024-01-03'), amount: 110 },
+                { date: new Date('2024-01-04'), amount: 130 }
+            ];
+
+            const result = computeAppreciationSeries(balanceData, contributionData);
+
+            expect(result.length).toBe(3); // Result should map to balanceData
+            // 2024-01-01
+            expect(result[0].value).toBe(0); // 100 - 100
+            // 2024-01-02 interpolation: time is between Jan 1 (100) and Jan 3 (110)
+            // Midpoint value should be 105. 120 - 105 = 15
+            expect(result[1].value).toBe(15);
+            // 2024-01-04
+            expect(result[2].value).toBe(20); // 150 - 130
+        });
+
+        it('should handle target time before first contribution', () => {
+            const balanceData = [
+                { date: new Date('2023-12-31'), value: 100 },
+            ];
+            const contributionData = [
+                { date: new Date('2024-01-01'), amount: 100 },
+            ];
+            const result = computeAppreciationSeries(balanceData, contributionData);
+            expect(result.length).toBe(1);
+            expect(result[0].value).toBe(0); // 100 - 100 (first contrib value)
+        });
+
+        it('should handle target time after last contribution', () => {
+            const balanceData = [
+                { date: new Date('2024-01-02'), value: 150 },
+            ];
+            const contributionData = [
+                { date: new Date('2024-01-01'), amount: 100 },
+            ];
+            const result = computeAppreciationSeries(balanceData, contributionData);
+            expect(result.length).toBe(1);
+            expect(result[0].value).toBe(50); // 150 - 100 (last contrib value)
+        });
+    });
+});

--- a/tests/js/transactions/chart/helpers.test.js
+++ b/tests/js/transactions/chart/helpers.test.js
@@ -1,4 +1,4 @@
-import { niceNumber, parseLocalDate, clampTime, clamp01, colorWithAlpha, parseColorToRgb } from '../../../../js/transactions/chart/helpers.js';
+import { niceNumber, parseLocalDate, clampTime, clamp01 } from '../../../../js/transactions/chart/helpers.js';
 
 describe('Chart Helpers', () => {
     describe('niceNumber', () => {

--- a/tests/js/transactions/chart/helpers.test.js
+++ b/tests/js/transactions/chart/helpers.test.js
@@ -1,0 +1,56 @@
+import { niceNumber, parseLocalDate, clampTime, clamp01, colorWithAlpha, parseColorToRgb } from '../../../../js/transactions/chart/helpers.js';
+
+describe('Chart Helpers', () => {
+    describe('niceNumber', () => {
+        it('should handle zero or non-finite range', () => {
+            expect(niceNumber(0, true)).toBe(1);
+            expect(niceNumber(NaN, false)).toBe(1);
+            expect(niceNumber(Infinity, true)).toBe(1);
+        });
+
+        it('should return nice fractions when rounding', () => {
+            expect(niceNumber(1.2, true)).toBe(1);
+            expect(niceNumber(2.5, true)).toBe(2);
+            expect(niceNumber(6.5, true)).toBe(5);
+            expect(niceNumber(8.5, true)).toBe(10);
+        });
+
+        it('should return nice fractions without rounding', () => {
+             expect(niceNumber(0.8, false)).toBe(1);
+             expect(niceNumber(1.5, false)).toBe(2);
+             expect(niceNumber(3.5, false)).toBe(5);
+             expect(niceNumber(8.5, false)).toBe(10);
+        });
+    });
+
+    describe('parseLocalDate', () => {
+        it('should parse YYYY-MM-DD string to timestamp', () => {
+            const timestamp = parseLocalDate('2023-10-25');
+            const date = new Date(timestamp);
+            expect(date.getUTCFullYear()).toBe(2023);
+            expect(date.getUTCMonth()).toBe(9); // 0-indexed
+            expect(date.getUTCDate()).toBe(25);
+        });
+
+        it('should fallback to JS Date parse for other formats', () => {
+            const timestamp = parseLocalDate('2023/10/25');
+            expect(timestamp).not.toBeNaN();
+        });
+    });
+
+    describe('clampTime', () => {
+        it('should clamp value within bounds', () => {
+            expect(clampTime(50, 0, 100)).toBe(50);
+            expect(clampTime(-10, 0, 100)).toBe(0);
+            expect(clampTime(150, 0, 100)).toBe(100);
+        });
+    });
+
+    describe('clamp01', () => {
+        it('should clamp value between 0 and 1', () => {
+            expect(clamp01(0.5)).toBe(0.5);
+            expect(clamp01(-0.5)).toBe(0);
+            expect(clamp01(1.5)).toBe(1);
+        });
+    });
+});

--- a/tests/js/transactions/table/parser.test.js
+++ b/tests/js/transactions/table/parser.test.js
@@ -1,0 +1,142 @@
+import { normalizeTickerToken, parseCommandPalette, deriveCompositionTickerFilters, matchesAssetClass } from '../../../../js/transactions/table/parser.js';
+
+// mock config
+jest.mock('../../../../js/config.js', () => ({
+    getHoldingAssetClass: jest.fn((ticker) => {
+        if (ticker === 'SPY' || ticker === 'VOO') {return 'etf';}
+        return 'stock'; // Default fallback in this mock
+    })
+}));
+
+describe('Table Parser Helpers', () => {
+    describe('normalizeTickerToken', () => {
+        it('should handle invalid inputs', () => {
+            expect(normalizeTickerToken(null)).toBeNull();
+            expect(normalizeTickerToken(123)).toBeNull();
+            expect(normalizeTickerToken({})).toBeNull();
+        });
+
+        it('should clean and uppercase string', () => {
+            expect(normalizeTickerToken('aapl')).toBe('AAPL');
+            expect(normalizeTickerToken(' msft ')).toBe('MSFT');
+            expect(normalizeTickerToken('BRK-B')).toBe('BRKB');
+        });
+
+        it('should return null for strings without letters', () => {
+            expect(normalizeTickerToken('123')).toBeNull();
+            expect(normalizeTickerToken('!@#')).toBeNull();
+            expect(normalizeTickerToken('')).toBeNull();
+        });
+
+        it('should use ticker alias map', () => {
+            expect(normalizeTickerToken('BRK')).toBe('BRKB');
+            expect(normalizeTickerToken('BRK-B')).toBe('BRKB');
+            expect(normalizeTickerToken('BRKB')).toBe('BRKB');
+        });
+    });
+
+    describe('parseCommandPalette', () => {
+        it('should parse empty string', () => {
+            expect(parseCommandPalette('')).toEqual({
+                text: '',
+                commands: {
+                    type: null,
+                    security: null,
+                    min: null,
+                    max: null,
+                    assetClass: null,
+                    tickers: []
+                }
+            });
+        });
+
+        it('should parse type', () => {
+            const res1 = parseCommandPalette('type:buy');
+            expect(res1.commands.type).toBe('buy');
+
+            const res2 = parseCommandPalette('type:sell');
+            expect(res2.commands.type).toBe('sell');
+
+            const res3 = parseCommandPalette('type:invalid');
+            expect(res3.commands.type).toBeNull();
+        });
+
+        it('should parse standalone asset class', () => {
+            expect(parseCommandPalette('etf').commands.assetClass).toBe('etf');
+            expect(parseCommandPalette('stock').commands.assetClass).toBe('stock');
+        });
+
+        it('should parse key:val asset class', () => {
+            expect(parseCommandPalette('asset:etf').commands.assetClass).toBe('etf');
+            expect(parseCommandPalette('class:stock').commands.assetClass).toBe('stock');
+        });
+
+        it('should parse min/max values', () => {
+            const res = parseCommandPalette('min:100 max:500');
+            expect(res.commands.min).toBe(100);
+            expect(res.commands.max).toBe(500);
+        });
+
+        it('should parse security', () => {
+            expect(parseCommandPalette('security:aapl').commands.security).toBe('AAPL');
+            expect(parseCommandPalette('s:msft').commands.security).toBe('MSFT');
+        });
+
+        it('should separate tickers and text tokens', () => {
+            // Note: with current normalizeTickerToken implementation, ANY word with letters is treated as a ticker.
+            // For example, "random" -> "RANDOM".
+            // The logic in parseCommandPalette is if it normalizes, it goes to tickers, otherwise text.
+            const res = parseCommandPalette('AAPL 123 MSFT !@#');
+            expect(res.commands.tickers).toEqual(['AAPL', 'MSFT']);
+            expect(res.text).toBe('123 !@#');
+        });
+
+        it('should handle unhandled key:value tokens', () => {
+             const res = parseCommandPalette('unknown:value');
+             // processKeyValToken takes the whole token "unknown:value" as the ticker if it fails to parse as a specific key.
+             expect(res.commands.tickers).toContain('UNKNOWNVALUE');
+        });
+    });
+
+    describe('deriveCompositionTickerFilters', () => {
+        it('should extract unique tickers from commands and text', () => {
+             const commands = { security: 'AAPL' };
+             const text = 'MSFT aapl GOOG 123';
+
+             const result = deriveCompositionTickerFilters(text, commands);
+             expect(result).toEqual(['AAPL', 'MSFT', 'GOOG']);
+        });
+
+        it('should handle null/empty commands or text', () => {
+             expect(deriveCompositionTickerFilters('', {})).toEqual([]);
+             expect(deriveCompositionTickerFilters(null, null)).toEqual([]);
+             expect(deriveCompositionTickerFilters('AAPL', null)).toEqual(['AAPL']);
+        });
+    });
+
+    describe('matchesAssetClass', () => {
+         it('should return true if no desired class is provided', () => {
+              expect(matchesAssetClass('AAPL', null)).toBe(true);
+              expect(matchesAssetClass('AAPL', '')).toBe(true);
+         });
+
+         it('should return true if security is not a string', () => {
+              expect(matchesAssetClass(123, 'etf')).toBe(true);
+              expect(matchesAssetClass(null, 'etf')).toBe(true);
+         });
+
+         it('should match etf', () => {
+              expect(matchesAssetClass('SPY', 'etf')).toBe(true);
+              expect(matchesAssetClass('AAPL', 'etf')).toBe(false);
+         });
+
+         it('should match stock', () => {
+              expect(matchesAssetClass('AAPL', 'stock')).toBe(true);
+              expect(matchesAssetClass('SPY', 'stock')).toBe(false);
+         });
+
+         it('should return true for unknown asset classes', () => {
+              expect(matchesAssetClass('AAPL', 'unknown')).toBe(true);
+         });
+    });
+});

--- a/tests/js/transactions/terminal/handlers/transaction.test.js
+++ b/tests/js/transactions/terminal/handlers/transaction.test.js
@@ -1,0 +1,163 @@
+import { handleTransactionCommand, handleDefaultCommand } from '../../../../../js/transactions/terminal/handlers/transaction.js';
+import { transactionState, setChartDateRange } from '../../../../../js/transactions/state.js';
+import * as viewUtils from '../../../../../js/transactions/terminal/viewUtils.js';
+import * as dateUtils from '../../../../../js/transactions/terminal/dateUtils.js';
+import * as terminalStats from '../../../../../js/transactions/terminalStats.js';
+import * as zoom from '../../../../../js/transactions/zoom.js';
+
+// Mocks
+jest.mock('../../../../../js/transactions/state.js', () => ({
+    transactionState: {
+        activeFilterTerm: '',
+        activeChart: 'performance',
+        selectedCurrency: 'USD'
+    },
+    setChartDateRange: jest.fn()
+}));
+
+jest.mock('../../../../../js/transactions/terminal/viewUtils.js', () => ({
+    isTransactionTableVisible: jest.fn(),
+    getActiveChartSummaryText: jest.fn(),
+    ensureTransactionTableVisible: jest.fn(),
+    isActiveChartVisible: jest.fn()
+}));
+
+jest.mock('../../../../../js/transactions/terminal/dateUtils.js', () => ({
+    updateContextYearFromRange: jest.fn(),
+    parseSimplifiedDateRange: jest.fn(),
+    formatDateRange: jest.fn()
+}));
+
+jest.mock('../../../../../js/transactions/zoom.js', () => ({
+    toggleZoom: jest.fn(),
+    getZoomState: jest.fn()
+}));
+
+jest.mock('../../../../../js/transactions/terminalStats.js', () => ({
+    getDynamicStatsText: jest.fn()
+}));
+
+describe('Transaction Command Handler', () => {
+    let mockContext;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockContext = {
+            toggleTable: jest.fn(),
+            filterAndSort: jest.fn(),
+            chartManager: { update: jest.fn() },
+            appendMessage: jest.fn()
+        };
+    });
+
+    describe('handleTransactionCommand', () => {
+        it('should toggle table when no args provided and return instructions', async () => {
+            await handleTransactionCommand([], mockContext);
+            expect(mockContext.toggleTable).toHaveBeenCalled();
+            expect(mockContext.appendMessage).toHaveBeenCalledWith(expect.stringContaining('Toggled transaction table'));
+        });
+
+        it('should apply valid date filter to table when table is visible', async () => {
+            // Setup table visible, chart hidden
+            viewUtils.isActiveChartVisible.mockReturnValue(false);
+            viewUtils.isTransactionTableVisible.mockReturnValue(true);
+            viewUtils.ensureTransactionTableVisible.mockReturnValue(true);
+
+            const mockRange = { from: new Date('2023-01-01'), to: new Date('2023-12-31') };
+            dateUtils.parseSimplifiedDateRange.mockReturnValue(mockRange);
+            dateUtils.formatDateRange.mockReturnValue('2023');
+
+            await handleTransactionCommand(['2023'], mockContext);
+
+            expect(dateUtils.parseSimplifiedDateRange).toHaveBeenCalledWith('2023');
+            expect(setChartDateRange).toHaveBeenCalledWith(mockRange);
+            expect(dateUtils.updateContextYearFromRange).toHaveBeenCalledWith(mockRange);
+            expect(mockContext.filterAndSort).toHaveBeenCalledWith('');
+            expect(mockContext.appendMessage).toHaveBeenCalledWith(expect.stringContaining('Applied date filter 2023 to transactions table'));
+        });
+
+        it('should apply valid date filter to active chart when chart is visible', async () => {
+            viewUtils.isActiveChartVisible.mockReturnValue(true);
+            viewUtils.getActiveChartSummaryText.mockResolvedValue('Chart summary');
+
+            const mockRange = { from: new Date('2023-01-01'), to: new Date('2023-12-31') };
+            dateUtils.parseSimplifiedDateRange.mockReturnValue(mockRange);
+            dateUtils.formatDateRange.mockReturnValue('2023');
+
+            await handleTransactionCommand(['2023'], mockContext);
+
+            expect(setChartDateRange).toHaveBeenCalledWith(mockRange);
+            expect(mockContext.chartManager.update).toHaveBeenCalled();
+            expect(mockContext.appendMessage).toHaveBeenCalledWith(expect.stringContaining('Applied date filter 2023 to performance chart.'));
+            expect(mockContext.appendMessage).toHaveBeenCalledWith(expect.stringContaining('Chart summary'));
+        });
+
+        it('should fallback to filter string if invalid date range', async () => {
+            dateUtils.parseSimplifiedDateRange.mockReturnValue({ from: null, to: null });
+            viewUtils.getActiveChartSummaryText.mockResolvedValue('Chart summary');
+
+            await handleTransactionCommand(['invalid'], mockContext);
+
+            expect(mockContext.filterAndSort).toHaveBeenCalledWith('invalid');
+            expect(mockContext.appendMessage).toHaveBeenCalledWith(expect.stringContaining('Filtering transactions by: "invalid"'));
+            expect(mockContext.appendMessage).toHaveBeenCalledWith(expect.stringContaining('Chart summary'));
+            expect(setChartDateRange).not.toHaveBeenCalled();
+        });
+
+        it('should append stats text if transaction table is visible', async () => {
+            viewUtils.isActiveChartVisible.mockReturnValue(false);
+            viewUtils.isTransactionTableVisible.mockReturnValue(true);
+            terminalStats.getDynamicStatsText.mockResolvedValue('Some dynamic stats');
+            dateUtils.parseSimplifiedDateRange.mockReturnValue({ from: null, to: null });
+
+            await handleTransactionCommand(['AAPL'], mockContext);
+
+            expect(mockContext.appendMessage).toHaveBeenCalledWith(expect.stringContaining('Some dynamic stats'));
+        });
+
+        it('should unzoom if zoomed', async () => {
+            zoom.getZoomState.mockReturnValue(true);
+            await handleTransactionCommand([], mockContext);
+            expect(zoom.toggleZoom).toHaveBeenCalled();
+        });
+    });
+
+    describe('handleDefaultCommand', () => {
+        it('should execute date filter if valid date range is parsed', async () => {
+            dateUtils.parseSimplifiedDateRange.mockReturnValue({ from: new Date() });
+
+            viewUtils.isActiveChartVisible.mockReturnValue(false);
+            viewUtils.isTransactionTableVisible.mockReturnValue(true);
+            viewUtils.ensureTransactionTableVisible.mockReturnValue(true);
+            dateUtils.formatDateRange.mockReturnValue('2023');
+
+            await handleDefaultCommand('2023', mockContext);
+
+            expect(dateUtils.parseSimplifiedDateRange).toHaveBeenCalledWith('2023');
+            expect(setChartDateRange).toHaveBeenCalled();
+            expect(mockContext.appendMessage).toHaveBeenCalledWith(expect.stringContaining('Applied date filter'));
+        });
+
+        it('should filter transactions if command is not a valid date range', async () => {
+            dateUtils.parseSimplifiedDateRange.mockReturnValue({ from: null, to: null });
+            viewUtils.isTransactionTableVisible.mockReturnValue(true);
+            terminalStats.getDynamicStatsText.mockResolvedValue('Some dynamic stats');
+
+            await handleDefaultCommand('notadate', mockContext);
+
+            expect(mockContext.filterAndSort).toHaveBeenCalledWith('notadate');
+            expect(mockContext.appendMessage).toHaveBeenCalledWith(expect.stringContaining('Some dynamic stats'));
+        });
+
+        it('should append summary text if chart is active instead of table', async () => {
+            dateUtils.parseSimplifiedDateRange.mockReturnValue({ from: null, to: null });
+            viewUtils.isTransactionTableVisible.mockReturnValue(false);
+            viewUtils.getActiveChartSummaryText.mockResolvedValue('Some summary');
+
+            await handleDefaultCommand('notadate', mockContext);
+
+            expect(mockContext.filterAndSort).toHaveBeenCalledWith('notadate');
+            expect(mockContext.appendMessage).toHaveBeenCalledWith(expect.stringContaining('Some summary'));
+        });
+    });
+});

--- a/tests/js/transactions/terminal/handlers/transaction.test.js
+++ b/tests/js/transactions/terminal/handlers/transaction.test.js
@@ -1,5 +1,5 @@
 import { handleTransactionCommand, handleDefaultCommand } from '../../../../../js/transactions/terminal/handlers/transaction.js';
-import { transactionState, setChartDateRange } from '../../../../../js/transactions/state.js';
+import { setChartDateRange } from '../../../../../js/transactions/state.js';
 import * as viewUtils from '../../../../../js/transactions/terminal/viewUtils.js';
 import * as dateUtils from '../../../../../js/transactions/terminal/dateUtils.js';
 import * as terminalStats from '../../../../../js/transactions/terminalStats.js';


### PR DESCRIPTION
This PR adds comprehensive unit test cases to improve the repository's test coverage in 4 specific utility/handler areas without modifying any application business logic.

The following areas now have proper test coverage ensuring behavior correctness using the Arrange-Act-Assert pattern:
1. `tests/js/transactions/chart/helpers.test.js`: Validates `niceNumber`, `parseLocalDate`, `clampTime`, and `clamp01` logic inside `js/transactions/chart/helpers.js`.
2. `tests/js/transactions/table/parser.test.js`: Validates `normalizeTickerToken`, `parseCommandPalette`, `deriveCompositionTickerFilters`, and `matchesAssetClass` inside `js/transactions/table/parser.js`.
3. `tests/js/transactions/terminal/handlers/transaction.test.js`: Validates `handleTransactionCommand` and `handleDefaultCommand` inside `js/transactions/terminal/handlers/transaction.js` by mocking out UI side-effects properly.
4. `tests/js/transactions/chart/data/contribution.test.js`: Validates `computeAppreciationSeries` inside `js/transactions/chart/data/contribution.js` ensuring correct calculation with interpolation for offset dates.

All tests pass using `pnpm run verify:all` and linting errors generated have been properly fixed.

---
*PR created automatically by Jules for task [13883491910987892433](https://jules.google.com/task/13883491910987892433) started by @ryusoh*