### PR TITLE
Add unit test coverage for Glow Trail and Glass3D plugins

### DIFF
--- a/.jules/testpilot.md
+++ b/.jules/testpilot.md
@@ -71,3 +71,7 @@ Result: Tested and verified gracefull exits for zero data/series, increasing sys
 ## 2024-05-25 - Chart Renderer Early Exits & Snapshot Tests
 
 **Learning:** When unit testing chart renderers like `beta.js` and `fx.js`, ensure you cover the early-exit branches that handle empty data (e.g. `seriesToDraw.length === 0`). This requires mocking out internal chart dependencies like `stopPerformanceAnimation` or `stopFxAnimation` correctly. Additionally, when testing data aggregation functions like `getPESnapshotLine` that format numbers, account for asynchronous mock overrides to maintain predictable test executions and reach isolated branches.
+
+## 2025-02-23 - Glow Trail Animator, Glass 3D Plugin, and Fade Control Testing
+
+**Learning:** When testing visual animation loops tied to requestAnimationFrame (e.g. `glowTrailAnimator`), manually triggering mocked RAF callbacks allows for deterministic phase advancement and verifies state reset logic. When verifying plugins that inject directly into Chart.js lifecycles, full object mocks for `datasetMeta` and partial mock `CanvasRenderingContext2D` ensures early branches exit safely before execution hits `TypeError` on null pointer properties.

--- a/tests/js/plugins/glass3dPlugin.test.js
+++ b/tests/js/plugins/glass3dPlugin.test.js
@@ -61,6 +61,7 @@ describe('glass3dPlugin', () => {
             ctx,
             glassPointerTarget: { x: 0.3, y: -0.2 },
             getDatasetMeta: jest.fn(() => ({ data: arcs })),
+            chartArea: { top: 0, bottom: 200, left: 0, right: 200 }
         };
         global.performance = { now: jest.fn(() => 1000) };
         window.pieChartGlassEffect = {
@@ -103,5 +104,23 @@ describe('glass3dPlugin', () => {
         };
         expect(() => glass3dPlugin.beforeDatasetsDraw(emptyChart, { meta: {} }, {})).not.toThrow();
         expect(() => glass3dPlugin.afterDatasetsDraw(emptyChart, { meta: {} }, {})).not.toThrow();
+    });
+
+    it('should handle doughnut inner hole rendering', () => {
+        const doughnutChart = {
+            ctx,
+            getDatasetMeta: jest.fn(() => ({ data: arcs })),
+            config: { type: 'doughnut' }
+        };
+        glass3dPlugin.beforeDatasetsDraw(doughnutChart, { meta: {} }, {});
+        expect(() => glass3dPlugin.afterDatasetsDraw(doughnutChart, { meta: {} }, {})).not.toThrow();
+        // Additional coverage for drawing hole geometry
+        expect(ctx.fill).toHaveBeenCalled();
+    });
+
+    it('should parse hex colors correctly for top highlights', () => {
+        arcs[0].options = { backgroundColor: '#ff0000' };
+        glass3dPlugin.beforeDatasetsDraw(chart, { meta: {} }, {});
+        expect(() => glass3dPlugin.afterDatasetsDraw(chart, { meta: {} }, {})).not.toThrow();
     });
 });

--- a/tests/js/plugins/glowTrailAnimator.test.js
+++ b/tests/js/plugins/glowTrailAnimator.test.js
@@ -1,0 +1,171 @@
+import { createGlowTrailAnimator } from '@plugins/glowTrailAnimator.js';
+
+describe('glowTrailAnimator', () => {
+    let animator;
+    let mockCtx;
+
+    beforeEach(() => {
+        animator = createGlowTrailAnimator({
+            enabled: true,
+            charts: {
+                disabledChart: { enabled: false },
+                customChart: { tailRatio: 0.5, oscillationSpeed: 2 }
+            }
+        });
+
+        const mockGradient = {
+            addColorStop: jest.fn()
+        };
+
+        mockCtx = {
+            createLinearGradient: jest.fn(() => mockGradient),
+            createRadialGradient: jest.fn(() => mockGradient),
+            save: jest.fn(),
+            restore: jest.fn(),
+            beginPath: jest.fn(),
+            moveTo: jest.fn(),
+            lineTo: jest.fn(),
+            stroke: jest.fn(),
+            arc: jest.fn(),
+            fill: jest.fn(),
+            globalCompositeOperation: '',
+            fillStyle: '',
+            strokeStyle: '',
+            shadowColor: '',
+            shadowBlur: 0,
+            lineWidth: 0,
+            globalAlpha: 1
+        };
+
+        jest.spyOn(global, 'requestAnimationFrame').mockImplementation((cb) => {
+            return setTimeout(() => cb(Date.now()), 0);
+        });
+        jest.spyOn(global, 'cancelAnimationFrame').mockImplementation((id) => {
+            clearTimeout(id);
+        });
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+        animator.stopAll();
+    });
+
+    describe('isEnabledFor', () => {
+        it('returns true for default chart', () => {
+            expect(animator.isEnabledFor('test')).toBe(true);
+        });
+
+        it('returns false when globally disabled', () => {
+            const disabledAnimator = createGlowTrailAnimator({ enabled: false });
+            expect(disabledAnimator.isEnabledFor('test')).toBe(false);
+        });
+
+        it('returns false for explicitly disabled chart', () => {
+            expect(animator.isEnabledFor('disabledChart')).toBe(false);
+        });
+    });
+
+    describe('scheduling and animation state', () => {
+        it('starts, advances, and stops animation', () => {
+            const mockChartManager = { redraw: jest.fn() };
+
+            animator.schedule('test', mockChartManager);
+            expect(global.requestAnimationFrame).toHaveBeenCalled();
+
+            const initialPhase = animator.advance('test', 1000);
+            expect(initialPhase).toBe(0);
+
+            const nextPhase = animator.advance('test', 1050);
+            expect(nextPhase).toBeGreaterThan(0);
+
+            animator.stop('test');
+        });
+
+        it('stops animation if isActive returns false', (done) => {
+            const mockChartManager = { redraw: jest.fn() };
+            animator.schedule('test', mockChartManager, { isActive: () => false });
+
+            setTimeout(() => {
+                expect(mockChartManager.redraw).not.toHaveBeenCalled();
+                done();
+            }, 10);
+        });
+
+        it('stopAll clears all active animations', () => {
+            animator.advance('chart1', 1000);
+            animator.advance('chart2', 1000);
+
+            animator.stopAll();
+
+            // Re-advancing should start from phase 0
+            expect(animator.advance('chart1', 2000)).toBe(0);
+        });
+    });
+
+    describe('drawSeriesGlow', () => {
+        it('does not draw if coords are empty', () => {
+            animator.drawSeriesGlow(mockCtx, { coords: [], color: '#ff0000', lineWidth: 2 }, { chartKey: 'test' });
+            expect(mockCtx.beginPath).not.toHaveBeenCalled();
+        });
+
+        it('does not draw if color is invalid', () => {
+            animator.drawSeriesGlow(mockCtx, { coords: [{x: 0, y: 0}], color: 'invalid', lineWidth: 2 }, { chartKey: 'test' });
+            expect(mockCtx.beginPath).not.toHaveBeenCalled();
+        });
+
+        it('draws halo and ring with valid coords and color', () => {
+            const series = {
+                coords: [{ x: 10, y: 10 }, { x: 20, y: 20 }],
+                color: '#ff0000',
+                lineWidth: 2
+            };
+
+            animator.drawSeriesGlow(mockCtx, series, { chartKey: 'test', isMobile: false, seriesIndex: 0 });
+
+            expect(mockCtx.createRadialGradient).toHaveBeenCalled();
+            expect(mockCtx.arc).toHaveBeenCalled();
+            expect(mockCtx.fill).toHaveBeenCalled();
+            expect(mockCtx.stroke).toHaveBeenCalled();
+        });
+
+        it('draws tail when tailRatio > 0 and coords are sufficient', () => {
+            const series = {
+                coords: Array.from({length: 20}, (_, i) => ({ x: i, y: i })),
+                color: 'rgb(255, 0, 0)',
+                lineWidth: 2
+            };
+
+            animator.drawSeriesGlow(mockCtx, series, { chartKey: 'customChart' });
+
+            expect(mockCtx.createLinearGradient).toHaveBeenCalled();
+            expect(mockCtx.lineTo).toHaveBeenCalled();
+        });
+
+        it('handles mobile and desktop specific settings', () => {
+            const series = {
+                coords: [{ x: 10, y: 10 }],
+                color: '#00ff00',
+                lineWidth: 2
+            };
+
+            animator.drawSeriesGlow(mockCtx, series, { chartKey: 'test', isMobile: true });
+            const mobileShadowBlur = mockCtx.shadowBlur;
+
+            animator.drawSeriesGlow(mockCtx, series, { chartKey: 'test', isMobile: false });
+            const desktopShadowBlur = mockCtx.shadowBlur;
+
+            expect(mobileShadowBlur).not.toEqual(desktopShadowBlur);
+        });
+
+        it('supports 3-digit hex colors', () => {
+            const series = {
+                coords: [{ x: 10, y: 10 }],
+                color: '#f00',
+                lineWidth: 2
+            };
+
+            animator.drawSeriesGlow(mockCtx, series, { chartKey: 'test' });
+            expect(mockCtx.beginPath).toHaveBeenCalled();
+        });
+    });
+});

--- a/tests/js/transactions/chart_core.test.js
+++ b/tests/js/transactions/chart_core.test.js
@@ -32,6 +32,45 @@ describe('composition ticker filtering helper', () => {
     });
 });
 
+describe('createChartManager', () => {
+    let createChartManager;
+
+    beforeEach(() => {
+        jest.resetModules();
+        jest.isolateModules(() => {
+            const chartModule = require('@js/transactions/chart.js');
+            createChartManager = chartModule.createChartManager;
+        });
+    });
+
+    it('handles redraw requests and skips when pending', () => {
+        const manager = createChartManager();
+        let rafCallback = null;
+        jest.spyOn(global, 'requestAnimationFrame').mockImplementation((cb) => {
+            rafCallback = cb;
+            return 123;
+        });
+
+        manager.redraw();
+        expect(global.requestAnimationFrame).toHaveBeenCalledTimes(1);
+
+        // Calling again should skip scheduling since it is pending
+        manager.redraw();
+        expect(global.requestAnimationFrame).toHaveBeenCalledTimes(1);
+
+        // Execute the callback
+        if (rafCallback) {
+            rafCallback(1000);
+        }
+
+        // Now we can redraw again
+        manager.redraw();
+        expect(global.requestAnimationFrame).toHaveBeenCalledTimes(2);
+
+        global.requestAnimationFrame.mockRestore();
+    });
+});
+
 describe('Minimum Tick Count Verification', () => {
     let generateConcreteTicks;
     let computePercentTickInfo;


### PR DESCRIPTION
This pull request addresses missing JavaScript test coverage in the project's visual rendering layers. It ensures that the `glowTrailAnimator` and `glass3dPlugin` are thoroughly evaluated within isolated Jest contexts, bypassing DOM dependencies. It also verifies that the main `createChartManager` properly deduplicates animation frames on redraw.

- Added `glowTrailAnimator.test.js`
- Added missing branch coverage in `glass3dPlugin.test.js`
- Added debouncing tests in `chart_core.test.js`
- Appended latest testing learnings to `testpilot.md`

---
*PR created automatically by Jules for task [17643949595284739375](https://jules.google.com/task/17643949595284739375) started by @ryusoh*