### PR TITLE
Palette: Add keyboard accessibility to terminal filter dropdowns

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -99,3 +99,8 @@
 
 **Learning:** Horizontally scrollable data visualization containers (like the calendar heatmap using `overflow-x: auto`) must be explicitly focusable. Otherwise, keyboard-only users cannot scroll to view off-screen data points.
 **Action:** Always add `tabindex="0"` and appropriate `:focus-visible` styling to horizontally scrollable data visualization containers.
+
+## 2026-05-18 - Keyboard Accessibility for Custom Dropdowns
+
+**Learning:** When custom interactive elements like dropdown lists are built using non-semantic `div` tags, they inherently lack keyboard accessibility. Keyboard-only and screen reader users cannot focus, navigate, or activate these elements without proper roles and tab management.
+**Action:** Always add `role="button"`, `tabindex="0"`, a `keydown` event listener for Enter/Space keys, and a `:focus-visible` styling state when transforming generic `div` containers into interactive dropdown menu options.

--- a/css/terminal/table.css
+++ b/css/terminal/table.css
@@ -228,14 +228,21 @@ th.sortable[data-sort='desc'] .sort-indicator::after {
     -webkit-backdrop-filter: blur(12px);
 }
 
-.filter-dropdown div {
+.filter-dropdown .filter-option {
     padding: 8px 12px;
     cursor: pointer;
     border-radius: 4px;
 }
 
-.filter-dropdown div:hover {
+.filter-dropdown .filter-option:hover,
+.filter-dropdown .filter-option:focus-visible {
     background-color: rgba(255, 255, 255, 0.06);
+    outline: none;
+}
+
+.filter-dropdown .filter-option:focus-visible {
+    outline: 2px solid rgba(255, 255, 255, 0.5);
+    outline-offset: -2px;
 }
 
 .table-responsive-container:focus-visible {

--- a/js/transactions/table.js
+++ b/js/transactions/table.js
@@ -246,7 +246,10 @@ function createFilterDropdown(column) {
         const div = document.createElement('div');
         div.className = 'filter-option';
         div.textContent = option;
-        div.addEventListener('click', (e) => {
+        div.role = 'button';
+        div.tabIndex = 0;
+
+        const triggerOption = (e) => {
             e.stopPropagation();
             const command =
                 option === 'All' ? '' : `${column === 'orderType' ? 'type' : 'security'}:${option}`;
@@ -256,6 +259,14 @@ function createFilterDropdown(column) {
             }
             filterAndSort(command);
             closeAllFilterDropdowns();
+        };
+
+        div.addEventListener('click', triggerOption);
+        div.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                triggerOption(e);
+            }
         });
         dropdown.appendChild(div);
     });


### PR DESCRIPTION
💡 **What**: Added `role="button"`, `tabindex="0"`, a `keydown` event listener for Enter/Space, and `:focus-visible` styling to the custom `.filter-option` `div` elements used in the terminal transaction table filter dropdowns. Also renamed the CSS selector from `.filter-dropdown div` to `.filter-dropdown .filter-option` for better specificity and added keyboard focus outlines.
🎯 **Why**: Because the filter dropdown options were built using generic `div` elements, they inherently lacked semantic meaning and keyboard focusability. Keyboard-only and screen reader users were previously unable to navigate to, focus on, or select these filter options.
♿ **Accessibility**: Makes custom interactive dropdowns fully operable via keyboard (Tab, Enter, Space) and perceivable to assistive technologies.

---
*PR created automatically by Jules for task [5006651411382154921](https://jules.google.com/task/5006651411382154921) started by @ryusoh*