### PR TITLE
Sentinel: [HIGH] Fix overly restrictive CORS subdomain validation

### DIFF
--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -52,7 +52,9 @@ function corsHeaders(origin) {
     try {
         if (origin) {
             const url = new URL(origin);
-            isSubdomain = url.protocol === 'https:' && url.hostname.endsWith('.lyeutsaon.com');
+            isSubdomain =
+                url.protocol === 'https:' &&
+                (url.hostname === 'lyeutsaon.com' || url.hostname.endsWith('.lyeutsaon.com'));
         }
     } catch (err) {
         // eslint-disable-next-line no-console


### PR DESCRIPTION
Fix overly restrictive CORS subdomain validation

The previous validation checked if the origin's hostname ended with `.lyeutsaon.com`. While this successfully prevented suffix attacks like `malicious-lyeutsaon.com`, it unintentionally prevented the apex domain `lyeutsaon.com` from accessing the worker.

This PR updates the check to explicitly allow the apex domain in addition to correctly structured subdomains, allowing `lyeutsaon.com` and `subdomain.lyeutsaon.com` but correctly rejecting `evil-lyeutsaon.com`.

---
*PR created automatically by Jules for task [1404800437493001375](https://jules.google.com/task/1404800437493001375) started by @ryusoh*