### PR TITLE
test: add unit tests for terminal misc handlers

### DIFF
--- a/.jules/testpilot.md
+++ b/.jules/testpilot.md
@@ -75,3 +75,10 @@ Result: Tested and verified gracefull exits for zero data/series, increasing sys
 ## 2025-02-23 - Glow Trail Animator, Glass 3D Plugin, and Fade Control Testing
 
 **Learning:** When testing visual animation loops tied to requestAnimationFrame (e.g. `glowTrailAnimator`), manually triggering mocked RAF callbacks allows for deterministic phase advancement and verifies state reset logic. When verifying plugins that inject directly into Chart.js lifecycles, full object mocks for `datasetMeta` and partial mock `CanvasRenderingContext2D` ensures early branches exit safely before execution hits `TypeError` on null pointer properties.
+## 2024-05-31 - Coverage Command Quirk
+- **Learning:** In this repository, `pnpm test` already runs with the `--coverage` flag configured in package.json. Appending `-- --coverage` causes Jest to interpret the flag as a literal test path regex, resulting in 'No tests found' errors.
+- **Action:** To check coverage, simply run `pnpm test` and examine its standard output.
+
+## 2024-05-31 - Mocking State Modules
+- **Learning:** When using `jest.mock` factory functions to mock state modules (like `js/transactions/state.js`), ensure all exported functions accessed or cleared in the tests (such as `setChartDateRange`) are explicitly included as `jest.fn()` in the returned mock object. Omitting them will cause `TypeError: ... is not a function` during test execution or teardown.
+- **Action:** Always double-check the module exports and ensure all accessed properties are mocked in the factory.

--- a/tests/js/transactions/terminal/handlers/misc.test.js
+++ b/tests/js/transactions/terminal/handlers/misc.test.js
@@ -1,9 +1,11 @@
 import {
+    handleClearCommand,
+    handleLabelCommand,
     handleMarketcapCommand,
     handleGeographyCommand,
     handleSectorsCommand,
 } from '../../../../../js/transactions/terminal/handlers/misc.js';
-import { transactionState, setActiveChart } from '../../../../../js/transactions/state.js';
+import { transactionState, setActiveChart, setChartDateRange } from '../../../../../js/transactions/state.js';
 
 jest.mock('../../../../../js/transactions/state.js', () => ({
     transactionState: {
@@ -326,5 +328,169 @@ describe('Misc Command Handlers', () => {
                 'Composition, Sectors, Geography, or Market Cap chart must be active. Use `plot composition`, `plot sectors`, `plot geography`, or `plot marketcap` first.'
             );
         });
+    });
+});
+
+describe('handleClearCommand', () => {
+    let terminalOutput;
+    let appendMessageMock;
+
+    beforeEach(() => {
+        terminalOutput = document.createElement('div');
+        terminalOutput.id = 'terminalOutput';
+        document.body.appendChild(terminalOutput);
+        appendMessageMock = jest.fn();
+    });
+
+    afterEach(() => {
+        if (terminalOutput) {
+            terminalOutput.remove();
+        }
+        setChartDateRange.mockClear();
+    });
+
+    it('should call clearOutput if it is a function', () => {
+        const clearOutputMock = jest.fn();
+        const closeAllFilterDropdownsMock = jest.fn();
+        const resetSortStateMock = jest.fn();
+        const filterAndSortMock = jest.fn();
+        const terminalInputMock = { value: 'some text' };
+
+        handleClearCommand([], {
+            clearOutput: clearOutputMock,
+            closeAllFilterDropdowns: closeAllFilterDropdownsMock,
+            resetSortState: resetSortStateMock,
+            filterAndSort: filterAndSortMock,
+            terminalInput: terminalInputMock,
+            appendMessage: appendMessageMock,
+        });
+
+        expect(clearOutputMock).toHaveBeenCalled();
+        expect(closeAllFilterDropdownsMock).toHaveBeenCalled();
+        expect(resetSortStateMock).toHaveBeenCalled();
+        expect(filterAndSortMock).toHaveBeenCalledWith('');
+        expect(terminalInputMock.value).toBe('');
+        expect(setChartDateRange).toHaveBeenCalledWith({ from: null, to: null });
+    });
+
+    it('should clear terminalOutput children if clearOutput is not a function (replaceChildren fallback)', () => {
+        const closeAllFilterDropdownsMock = jest.fn();
+        const resetSortStateMock = jest.fn();
+        const filterAndSortMock = jest.fn();
+        const terminalInputMock = { value: 'some text' };
+
+        terminalOutput.appendChild(document.createElement('div'));
+        terminalOutput.replaceChildren = jest.fn(); // Mock replaceChildren
+
+        handleClearCommand([], {
+            closeAllFilterDropdowns: closeAllFilterDropdownsMock,
+            resetSortState: resetSortStateMock,
+            filterAndSort: filterAndSortMock,
+            terminalInput: terminalInputMock,
+            appendMessage: appendMessageMock,
+        });
+
+        expect(terminalOutput.replaceChildren).toHaveBeenCalled();
+        expect(closeAllFilterDropdownsMock).toHaveBeenCalled();
+        expect(resetSortStateMock).toHaveBeenCalled();
+        expect(setChartDateRange).toHaveBeenCalledWith({ from: null, to: null });
+    });
+
+    it('should clear terminalOutput textContent if clearOutput is not a function and replaceChildren does not exist (jsdom fallback)', () => {
+        const closeAllFilterDropdownsMock = jest.fn();
+        const resetSortStateMock = jest.fn();
+        const filterAndSortMock = jest.fn();
+        const terminalInputMock = { value: 'some text' };
+
+        terminalOutput.appendChild(document.createElement('div'));
+        // In jsdom, replaceChildren might exist, so we force it to undefined to test the fallback
+        const originalReplaceChildren = terminalOutput.replaceChildren;
+        terminalOutput.replaceChildren = undefined;
+
+        handleClearCommand([], {
+            closeAllFilterDropdowns: closeAllFilterDropdownsMock,
+            resetSortState: resetSortStateMock,
+            filterAndSort: filterAndSortMock,
+            terminalInput: terminalInputMock,
+            appendMessage: appendMessageMock,
+        });
+
+        expect(terminalOutput.textContent).toBe('');
+        expect(closeAllFilterDropdownsMock).toHaveBeenCalled();
+        expect(resetSortStateMock).toHaveBeenCalled();
+        expect(setChartDateRange).toHaveBeenCalledWith({ from: null, to: null });
+
+        // Restore for other tests
+        terminalOutput.replaceChildren = originalReplaceChildren;
+    });
+});
+
+describe('handleLabelCommand', () => {
+    let appendMessageMock;
+    let chartManagerMock;
+
+    beforeEach(() => {
+        appendMessageMock = jest.fn();
+        chartManagerMock = {
+            redraw: jest.fn(),
+        };
+        // Reset transaction state before each test
+        transactionState.showChartLabels = undefined;
+    });
+
+    it('should toggle showChartLabels to true if it is explicitly false', () => {
+        // Let's set it to false explicitly first
+        transactionState.showChartLabels = false;
+
+        handleLabelCommand([], {
+            appendMessage: appendMessageMock,
+            chartManager: chartManagerMock
+        });
+
+
+        expect(transactionState.showChartLabels).toBe(true);
+        expect(appendMessageMock).toHaveBeenCalledWith('Chart labels are now visible.');
+        expect(chartManagerMock.redraw).toHaveBeenCalled();
+    });
+
+    it('should toggle showChartLabels to false if initially true', () => {
+        transactionState.showChartLabels = true;
+
+        handleLabelCommand([], {
+            appendMessage: appendMessageMock,
+            chartManager: chartManagerMock
+        });
+
+
+        expect(transactionState.showChartLabels).toBe(false);
+        expect(appendMessageMock).toHaveBeenCalledWith('Chart labels are now hidden.');
+        expect(chartManagerMock.redraw).toHaveBeenCalled();
+    });
+
+    it('should not throw if chartManager.redraw is not a function', () => {
+        transactionState.showChartLabels = true;
+
+        expect(() => {
+            handleLabelCommand([], {
+                appendMessage: appendMessageMock,
+                chartManager: {} // No redraw function
+            });
+        }).not.toThrow();
+
+        expect(transactionState.showChartLabels).toBe(false);
+        expect(appendMessageMock).toHaveBeenCalledWith('Chart labels are now hidden.');
+    });
+
+    it('should not throw if chartManager is undefined', () => {
+        transactionState.showChartLabels = true;
+
+        expect(() => {
+            handleLabelCommand([], {
+                appendMessage: appendMessageMock,
+            });
+        }).not.toThrow();
+
+        expect(transactionState.showChartLabels).toBe(false);
+        expect(appendMessageMock).toHaveBeenCalledWith('Chart labels are now hidden.');
     });
 });


### PR DESCRIPTION
This PR addresses missing coverage in `js/transactions/terminal/handlers/misc.js` by adding comprehensive tests for `handleClearCommand` and `handleLabelCommand`. This increases test coverage and ensures the terminal's utility commands behave predictably in the DOM and when altering global transaction state.

---
*PR created automatically by Jules for task [18010323351086156339](https://jules.google.com/task/18010323351086156339) started by @ryusoh*