### PR TITLE
⚡ Bolt: Cache percentInterpolators to eliminate GC overhead during chart interaction

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -237,3 +237,6 @@
 
 **Learning:** Using `.forEach()` inside tight charting rendering loops (such as `activeTickerOrder.forEach` wrapping `dates.forEach` to trace stacked area paths in `composition.js`, `sectors.js`, and `geography.js`) implicitly allocates closures on every frame. For complex charts with numerous groups and hundreds of date points, this compounds significantly, generating severe garbage collection (GC) pressure that can lead to micro-stutters and dropped frames during interaction or animation.
 **Action:** Always replace `.forEach()` iterations with standard, index-based `for` loops within critical high-frequency chart rendering code paths to eliminate closure allocation overhead entirely.
+## 2024-05-18 - Caching derived objects during high-frequency events
+**Learning:** Doing `new Date(dates[j])` and repeatedly constructing interpolators with `createTimeInterpolator()` inside high-frequency hover event handlers (like chart crosshair drawing) causes severe CPU and Garbage Collection (GC) degradation due to constant array allocations and closure recreations.
+**Action:** Cache derived objects like interpolators directly on the `layout` state object during the first hover interaction so they can be reused on subsequent hover event frames, changing an O(H*N) per-frame operation to an O(1) lookup per frame.

--- a/js/transactions/chart/interaction.js
+++ b/js/transactions/chart/interaction.js
@@ -275,13 +275,19 @@ export function drawCrosshairOverlay(ctx, layout) {
             if (!isAbsoluteMode) {
                 percentValue = holding.value;
             } else if (layout.percentSeriesMap && layout.percentSeriesMap[holding.key]) {
-                const dates = layout.dates || [];
-                const timePoints = new Array(dates.length);
-                const holdingSeries = layout.percentSeriesMap[holding.key];
-                for (let j = 0; j < dates.length; j++) {
-                    timePoints[j] = { time: new Date(dates[j]).getTime(), value: holdingSeries[j] };
+                // Bolt: Cache interpolators on layout to avoid rebuilding them and repeatedly calling new Date() on every hover event frame
+                layout.percentInterpolators = layout.percentInterpolators || {};
+                let interpolator = layout.percentInterpolators[holding.key];
+                if (!interpolator) {
+                    const dates = layout.dates || [];
+                    const timePoints = new Array(dates.length);
+                    const holdingSeries = layout.percentSeriesMap[holding.key];
+                    for (let j = 0; j < dates.length; j++) {
+                        timePoints[j] = { time: new Date(dates[j]).getTime(), value: holdingSeries[j] };
+                    }
+                    interpolator = createTimeInterpolator(timePoints);
+                    layout.percentInterpolators[holding.key] = interpolator;
                 }
-                const interpolator = createTimeInterpolator(timePoints);
                 percentValue = interpolator(time) ?? 0;
             } else {
                 percentValue = totalValueBase > 0 ? (holding.value / totalValueBase) * 100 : 0;


### PR DESCRIPTION
💡 What: Caches the output of `createTimeInterpolator()` directly on the `layout.percentInterpolators` object inside `drawCrosshairOverlay` in `js/transactions/chart/interaction.js`.
🎯 Why: `createTimeInterpolator` was being called repeatedly inside the high-frequency `mousemove` handler for the chart crosshair. For each holding on each frame, it executed `new Date(dates[j]).getTime()` hundreds or thousands of times, generating massive array and closure allocation overhead leading to Garbage Collection pauses and UI stuttering.
📊 Impact: Eliminates massive, continuous garbage collection during chart hovering. Replaces an O(H * N) array allocation loop with an O(1) object property lookup per frame.
🔬 Measurement: Verify by rendering the composition or sector allocation charts, opening the browser profiler, and hovering back and forth. The heap allocations and main thread CPU usage will be drastically lower.

---
*PR created automatically by Jules for task [15503490330481473281](https://jules.google.com/task/15503490330481473281) started by @ryusoh*