### PR TITLE
test: improve test coverage for terminal handlers, snapshots, and analysis data loader

### DIFF
--- a/js/pages/analysis/lab.js
+++ b/js/pages/analysis/lab.js
@@ -1081,4 +1081,5 @@ export const __analysisLabTesting = {
     state,
     normalizeConfig,
     buildPortfolioConfig,
+    fetchText,
 };

--- a/tests/js/pages/analysis/lab.test.js
+++ b/tests/js/pages/analysis/lab.test.js
@@ -103,6 +103,44 @@ describe('analysis lab data loading', () => {
         expect(baseScenario.precomputedEarningsCagr).toBeCloseTo(0.6 * 0.1 + 0.4 * 0.25, 5);
     });
 
+    describe('fetchText', () => {
+        it('fetches text successfully', async () => {
+            // Arrange
+            global[FLAG] = true;
+            global.fetch = jest.fn().mockResolvedValue({
+                ok: true,
+                text: jest.fn().mockResolvedValue('markdown content'),
+            });
+            const module = await import('@pages/analysis/lab.js');
+            const { fetchText } = module.__analysisLabTesting;
+
+            // Act
+            const text = await fetchText('../docs/thesis/TEST.md');
+
+            // Assert
+            expect(text).toBe('markdown content');
+            expect(global.fetch).toHaveBeenCalledWith(
+                expect.stringContaining('/docs/thesis/TEST.md'),
+                { cache: 'no-store' }
+            );
+        });
+
+        it('throws error when fetch fails', async () => {
+            // Arrange
+            global[FLAG] = true;
+            global.fetch = jest.fn().mockResolvedValue({
+                ok: false,
+            });
+            const module = await import('@pages/analysis/lab.js');
+            const { fetchText } = module.__analysisLabTesting;
+
+            // Act & Assert
+            await expect(fetchText('../docs/thesis/TEST.md')).rejects.toThrow(
+                'Failed to load ../docs/thesis/TEST.md'
+            );
+        });
+    });
+
     describe('extractScenarioTitles and stripWrappingQuotes', () => {
         let extractScenarioTitles;
 

--- a/tests/js/transactions/terminal/handlers/misc.test.js
+++ b/tests/js/transactions/terminal/handlers/misc.test.js
@@ -25,6 +25,7 @@ jest.mock('../../../../../js/transactions/terminal/snapshots.js', () => ({
     getSectorsSnapshotLine: jest.fn().mockResolvedValue('Mocked sectors summary'),
     getGeographySnapshotLine: jest.fn().mockResolvedValue('Mocked geography summary'),
     getMarketcapSnapshotLine: jest.fn().mockResolvedValue('Mocked marketcap summary'),
+    getFxSnapshotLine: jest.fn().mockReturnValue(null),
 }));
 
 describe('Misc Command Handlers', () => {
@@ -38,6 +39,33 @@ describe('Misc Command Handlers', () => {
         document.body.innerHTML = `
             <div id="runningAmountSection" class="is-hidden"></div>
         `;
+    });
+
+    describe('handleAllCommand', () => {
+        it('clears all filters, resets sorts, dates, and updates chart', async () => {
+            // Arrange
+            const closeAllFilterDropdowns = jest.fn();
+            const resetSortState = jest.fn();
+            const filterAndSort = jest.fn();
+            const chartManager = { update: jest.fn() };
+
+            const { handleAllCommand } = await import('@js/transactions/terminal/handlers/misc.js');
+
+            // Act
+            await handleAllCommand([], {
+                appendMessage: appendMessageMock,
+                closeAllFilterDropdowns,
+                resetSortState,
+                filterAndSort,
+                chartManager,
+            });
+
+            // Assert
+            expect(closeAllFilterDropdowns).toHaveBeenCalled();
+            expect(resetSortState).toHaveBeenCalled();
+            expect(filterAndSort).toHaveBeenCalledWith('');
+            expect(appendMessageMock).toHaveBeenCalledWith('Showing all data (filters and date ranges cleared).');
+        });
     });
 
     describe('handleMarketcapCommand', () => {

--- a/tests/js/transactions/terminal/snapshots.test.js
+++ b/tests/js/transactions/terminal/snapshots.test.js
@@ -1,9 +1,14 @@
-import { getYieldSnapshotLine } from '@js/transactions/terminal/snapshots.js';
+import { getYieldSnapshotLine, getFxSnapshotLine } from '@js/transactions/terminal/snapshots.js';
 import { transactionState } from '@js/transactions/state.js';
 import { loadYieldData } from '@js/transactions/chart/renderers/yield.js';
+import { buildFxChartSeries } from '@js/transactions/chart/renderers/fx.js';
 
 jest.mock('@js/transactions/chart/renderers/yield.js', () => ({
     loadYieldData: jest.fn(),
+}));
+
+jest.mock('@js/transactions/chart/renderers/fx.js', () => ({
+    buildFxChartSeries: jest.fn(),
 }));
 
 jest.mock('@js/transactions/chart/helpers.js', () => ({
@@ -25,6 +30,42 @@ describe('snapshots.js', () => {
         jest.clearAllMocks();
         transactionState.chartDateRange = { from: null, to: null };
         transactionState.selectedCurrency = 'USD';
+    });
+
+    describe('getFxSnapshotLine', () => {
+        it('returns null if activeChart is not fx', () => {
+            transactionState.activeChart = 'performance';
+            expect(getFxSnapshotLine()).toBeNull();
+        });
+
+        it('returns null if buildFxChartSeries returns empty', () => {
+            transactionState.activeChart = 'fx';
+            buildFxChartSeries.mockReturnValue([]);
+            expect(getFxSnapshotLine()).toBeNull();
+        });
+
+        it('returns formatted FX snapshot line when data is available', () => {
+            // Arrange
+            transactionState.activeChart = 'fx';
+            transactionState.selectedCurrency = 'USD';
+            transactionState.chartVisibility = {
+                'EUR': true,
+                'GBP': false, // this one is hidden
+                'JPY': true
+            };
+            buildFxChartSeries.mockReturnValue([
+                { key: 'EUR', quote: 'EUR', data: [{ value: 0.8 }, { value: 0.95 }] },
+                { key: 'GBP', quote: 'GBP', data: [{ value: 0.7 }] },
+                { key: 'JPY', quote: 'JPY', data: [{ value: 110 }] },
+                { key: 'CAD', quote: 'CAD', data: [] } // empty data should be skipped
+            ]);
+
+            // Act
+            const result = getFxSnapshotLine();
+
+            // Assert
+            expect(result).toBe('FX (USD base): USD/EUR 0.9500   USD/JPY 110.0');
+        });
     });
 
     describe('getYieldSnapshotLine', () => {


### PR DESCRIPTION
This pull request acts on TestPilot's directive to discover and fill 3 critical unit testing gaps across the codebase without modifying any business logic.

Targeting isolated unit functionalities based on an evaluation of `pnpm test --coverage`:
1. Tested the data-fetching utility `fetchText` in the Analysis Lab.
2. Verified the filtering clearing logic in Terminal's `handleAllCommand`.
3. Assessed missing snapshot layout behaviors for the `getFxSnapshotLine` transformer.

All tests utilize Jest, strictly adhere to the Arrange-Act-Assert structure, and successfully pass while pushing the `js/transactions/terminal/snapshots.js`, `js/pages/analysis/lab.js`, and `js/transactions/terminal/handlers/misc.js` coverages higher.

---
*PR created automatically by Jules for task [13166339333773056663](https://jules.google.com/task/13166339333773056663) started by @ryusoh*