### PR TITLE
Bolt: Replace .forEach closures in chart rendering loops

### DIFF
--- a/js/transactions/chart/renderers/beta.js
+++ b/js/transactions/chart/renderers/beta.js
@@ -60,51 +60,54 @@ export async function drawBetaChart(ctx, chartManager, timestamp) {
             return a.localeCompare(b);
         });
 
-    orderedKeys.forEach((key) => {
+    for (let i = 0; i < orderedKeys.length; i++) {
+        const key = orderedKeys[i];
         if (transactionState.chartVisibility[key] === undefined) {
             transactionState.chartVisibility[key] = key === '^LZ' || key === '^GSPC';
         }
-    });
+    }
 
     // Enforce "one benchmark" rule
     const visibleBenchmarks = allowedBenchmarks.filter(
         (b) => transactionState.chartVisibility[b] === true
     );
     if (visibleBenchmarks.length > 1) {
-        visibleBenchmarks.slice(1).forEach((b) => {
-            transactionState.chartVisibility[b] = false;
-        });
+        const toHide = visibleBenchmarks.slice(1);
+        for (let i = 0; i < toHide.length; i++) {
+            transactionState.chartVisibility[toHide[i]] = false;
+        }
     }
 
     // 1. Calculate daily returns
     const returnsMap = {};
-    orderedKeys.forEach((key) => {
+    for (let i = 0; i < orderedKeys.length; i++) {
+        const key = orderedKeys[i];
         const points = performanceSeries[key] || [];
         const sourceCurrency = PERFORMANCE_SERIES_CURRENCY[key] || 'USD';
         const returns = [];
-        for (let i = 1; i < points.length; i++) {
+        for (let j = 1; j < points.length; j++) {
             const startVal = convertBetweenCurrencies(
-                Number(points[i - 1].value),
+                Number(points[j - 1].value),
                 sourceCurrency,
-                points[i - 1].date,
+                points[j - 1].date,
                 selectedCurrency
             );
             const endVal = convertBetweenCurrencies(
-                Number(points[i].value),
+                Number(points[j].value),
                 sourceCurrency,
-                points[i].date,
+                points[j].date,
                 selectedCurrency
             );
             if (startVal !== 0) {
                 returns.push({
-                    date: points[i].date,
-                    time: parseLocalDate(points[i].date).getTime(),
+                    date: points[j].date,
+                    time: parseLocalDate(points[j].date).getTime(),
                     val: endVal / startVal - 1,
                 });
             }
         }
         returnsMap[key] = returns;
-    });
+    }
 
     const marketReturns = returnsMap[MARKET_REF];
     if (!marketReturns || marketReturns.length < 20) {
@@ -330,9 +333,10 @@ export async function drawBetaChart(ctx, chartManager, timestamp) {
         return 0;
     });
 
-    seriesForDrawing.forEach((series) => {
+    for (let i = 0; i < seriesForDrawing.length; i++) {
+        const series = seriesForDrawing[i];
         if (series.data.length === 0) {
-            return;
+            continue;
         }
 
         // Use raw points for Beta to ensure statistical accuracy (no smoothing)
@@ -361,13 +365,14 @@ export async function drawBetaChart(ctx, chartManager, timestamp) {
         }
 
         ctx.beginPath();
-        coords.forEach((c, idx) => {
+        for (let idx = 0; idx < coords.length; idx++) {
+            const c = coords[idx];
             if (idx === 0) {
                 ctx.moveTo(c.x, c.y);
             } else {
                 ctx.lineTo(c.x, c.y);
             }
-        });
+        }
         ctx.strokeStyle = resolvedColor;
         if (gradientStops) {
             const grad = ctx.createLinearGradient(padding.left, 0, padding.left + plotWidth, 0);
@@ -402,7 +407,7 @@ export async function drawBetaChart(ctx, chartManager, timestamp) {
             );
             glowIndex += 1;
         }
-    });
+    }
 
     if (isAnimationEnabled('performance') && glowIndex > 0) {
         schedulePerformanceAnimation(chartManager);
@@ -411,7 +416,8 @@ export async function drawBetaChart(ctx, chartManager, timestamp) {
     }
 
     if (getShowChartLabels()) {
-        renderedSeries.forEach((s) => {
+        for (let i = 0; i < renderedSeries.length; i++) {
+            const s = renderedSeries[i];
             drawEndValue(
                 ctx,
                 s.x,
@@ -426,7 +432,7 @@ export async function drawBetaChart(ctx, chartManager, timestamp) {
                 true,
                 []
             );
-        });
+        }
     }
 
     chartLayouts.beta = {

--- a/js/transactions/chart/renderers/fx.js
+++ b/js/transactions/chart/renderers/fx.js
@@ -182,8 +182,10 @@ export function drawFxChart(ctx, chartManager, timestamp) {
     let dataMin = Infinity;
     let dataMax = -Infinity;
 
-    filteredSeries.forEach((series) => {
-        series.data.forEach((point) => {
+    for (let i = 0; i < filteredSeries.length; i++) {
+        const series = filteredSeries[i];
+        for (let j = 0; j < series.data.length; j++) {
+            const point = series.data[j];
             const time = point.date.getTime();
             if (Number.isFinite(time)) {
                 minTime = Math.min(minTime, time);
@@ -193,8 +195,8 @@ export function drawFxChart(ctx, chartManager, timestamp) {
                 dataMin = Math.min(dataMin, point.percent);
                 dataMax = Math.max(dataMax, point.percent);
             }
-        });
-    });
+        }
+    }
 
     if (!Number.isFinite(minTime) || !Number.isFinite(maxTime) || minTime === maxTime) {
         chartLayouts.fx = null;
@@ -261,10 +263,11 @@ export function drawFxChart(ctx, chartManager, timestamp) {
     const showChartLabels = getShowChartLabels();
     const renderedSeries = [];
     const labelBounds = [];
-    filteredSeries.forEach((series) => {
+    for (let i = 0; i < filteredSeries.length; i++) {
+        const series = filteredSeries[i];
         const visibility = transactionState.chartVisibility[series.key];
         if (visibility === false) {
-            return;
+            continue;
         }
 
         const smoothingConfig = getSmoothingConfig('performance');
@@ -337,13 +340,14 @@ export function drawFxChart(ctx, chartManager, timestamp) {
         }
 
         ctx.beginPath();
-        coords.forEach((coord, index) => {
-            if (index === 0) {
+        for (let j = 0; j < coords.length; j++) {
+            const coord = coords[j];
+            if (j === 0) {
                 ctx.moveTo(coord.x, coord.y);
             } else {
                 ctx.lineTo(coord.x, coord.y);
             }
-        });
+        }
         ctx.lineWidth = CHART_LINE_WIDTHS.fx ?? 2;
         ctx.strokeStyle = strokeGradient;
         ctx.stroke();
@@ -390,7 +394,7 @@ export function drawFxChart(ctx, chartManager, timestamp) {
             );
             glowIndex += 1;
         }
-    });
+    }
 
     if (!renderedSeries.length) {
         stopFxAnimation();

--- a/js/transactions/chart/renderers/performance.js
+++ b/js/transactions/chart/renderers/performance.js
@@ -59,11 +59,12 @@ export async function drawPerformanceChart(ctx, chartManager, timestamp) {
         return a.localeCompare(b);
     });
 
-    orderedKeys.forEach((key) => {
+    for (let i = 0; i < orderedKeys.length; i++) {
+        const key = orderedKeys[i];
         if (transactionState.chartVisibility[key] === undefined) {
             transactionState.chartVisibility[key] = key === '^LZ' || key === '^GSPC';
         }
-    });
+    }
 
     const allPossibleSeries = orderedKeys.map((key) => {
         const points = Array.isArray(performanceSeries[key]) ? performanceSeries[key] : [];
@@ -282,10 +283,11 @@ export async function drawPerformanceChart(ctx, chartManager, timestamp) {
 
     const performanceBaselineY = yScale(0);
 
-    seriesForDrawing.forEach((series) => {
+    for (let i = 0; i < seriesForDrawing.length; i++) {
+        const series = seriesForDrawing[i];
         const isVisible = transactionState.chartVisibility[series.key] !== false;
         if (!isVisible || !Array.isArray(series.data) || series.data.length === 0) {
-            return;
+            continue;
         }
 
         // Apply smoothing to the series data
@@ -334,13 +336,14 @@ export async function drawPerformanceChart(ctx, chartManager, timestamp) {
         }
 
         ctx.beginPath();
-        coords.forEach((coord, index) => {
-            if (index === 0) {
+        for (let j = 0; j < coords.length; j++) {
+            const coord = coords[j];
+            if (j === 0) {
                 ctx.moveTo(coord.x, coord.y);
             } else {
                 ctx.lineTo(coord.x, coord.y);
             }
-        });
+        }
         ctx.lineWidth = lineThickness;
         ctx.stroke();
 
@@ -371,7 +374,7 @@ export async function drawPerformanceChart(ctx, chartManager, timestamp) {
             );
             glowIndex += 1;
         }
-    });
+    }
 
     if (renderedSeries.length === 0) {
         stopPerformanceAnimation();
@@ -397,7 +400,8 @@ export async function drawPerformanceChart(ctx, chartManager, timestamp) {
     const showChartLabels = getShowChartLabels();
     const labelBounds = [];
     if (showChartLabels) {
-        renderedSeries.forEach((series) => {
+        for (let i = 0; i < renderedSeries.length; i++) {
+            const series = renderedSeries[i];
             const { x, y, color, value } = series;
 
             const bounds = drawEndValue(
@@ -417,7 +421,7 @@ export async function drawPerformanceChart(ctx, chartManager, timestamp) {
             if (bounds) {
                 labelBounds.push(bounds);
             }
-        });
+        }
     }
 
     chartLayouts.performance = {


### PR DESCRIPTION
💡 What: Replaced `.forEach` closures with index-based `for` loops in chart renderers (`fx.js`, `beta.js`, `performance.js`).
🎯 Why: `.forEach` implicitly allocates new closure functions on every frame tick/mouse move inside extremely high-frequency event loops like pointer hover iterations and animation drawing steps. In large composite charts with multiple overlaid series, this exponentially increases short-lived heap allocations, leading to heavy GC overhead and resulting micro-stutters during interactivity.
📊 Impact: Eliminates closure creation overhead per rendering frame entirely, leading to smoother animations and a more stable framerate.
🔬 Measurement: Use the Chrome DevTools Performance Profiler and compare the heap allocations and garbage collection duration on interactive charts containing multiple overlay series (such as performance/beta charts with benchmarks).

---
*PR created automatically by Jules for task [18098909977693053572](https://jules.google.com/task/18098909977693053572) started by @ryusoh*