### PR TITLE
Fix: Add Security Headers to Cloudflare Worker JSON Responses

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -72,3 +72,8 @@ error_msg = error_msg.replace(urllib.parse.quote(api_key), "***")
 **Vulnerability:** External `fetch` requests to third-party APIs (like Alpaca and Yahoo Finance) in the Cloudflare Worker (`worker/src/index.js`) did not have an explicit timeout configured. If the upstream service became unresponsive or excessively slow, the worker execution could hang until it hit the platform's hard limits, leading to resource exhaustion, elevated latency, and potential Denial of Service (DoS) for the application.
 **Learning:** Cloudflare Workers and standard `fetch` APIs do not have a default timeout for outbound requests. When building resilient security architectures, relying on external availability without bounds check is a risk.
 **Prevention:** Always use `AbortSignal.timeout(ms)` to enforce strict timeouts on all external `fetch` calls, ensuring the system fails fast and securely rather than hanging indefinitely.
+
+## 2025-05-24 - [SECURITY ENHANCEMENT] Add Content-Security-Policy and X-Frame-Options to Worker APIs
+**Vulnerability:** The Cloudflare worker JSON responses did not include `Content-Security-Policy` and `X-Frame-Options` headers. While JSON endpoints typically aren't executed in browsers, strict defense-in-depth principles require ensuring API endpoints can never be unexpectedly framed, executed, or embedded via content-type sniffing or browser quirks.
+**Learning:** Security headers should be explicitly applied even to serverless/edge JSON APIs to prevent framing and script execution.
+**Prevention:** Added `Content-Security-Policy: default-src 'none'; frame-ancestors 'none'` and `X-Frame-Options: DENY` to the `jsonResponse` wrapper in `worker/src/index.js` to strictly enforce that the JSON payload cannot be executed or framed.

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -81,6 +81,8 @@ function jsonResponse(data, status, origin, extraHeaders = {}) {
             'Content-Type': 'application/json',
             'X-Content-Type-Options': 'nosniff',
             'Strict-Transport-Security': 'max-age=31536000; includeSubDomains',
+            'Content-Security-Policy': "default-src 'none'; frame-ancestors 'none'",
+            'X-Frame-Options': 'DENY',
             ...corsHeaders(origin),
             ...extraHeaders,
         },


### PR DESCRIPTION
Adds Content-Security-Policy and X-Frame-Options headers to the Cloudflare Worker JSON responses to prevent framing and script execution via content sniffing or browser quirks.

---
*PR created automatically by Jules for task [10294608304470327465](https://jules.google.com/task/10294608304470327465) started by @ryusoh*