### PR TITLE
🎨 Palette: Add tooltips to visually ambiguous icon buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -99,3 +99,8 @@
 
 **Learning:** Horizontally scrollable data visualization containers (like the calendar heatmap using `overflow-x: auto`) must be explicitly focusable. Otherwise, keyboard-only users cannot scroll to view off-screen data points.
 **Action:** Always add `tabindex="0"` and appropriate `:focus-visible` styling to horizontally scrollable data visualization containers.
+
+## 2025-03-09 - Ensure Visually Ambiguous Icon Buttons Have Tooltips
+
+**Learning:** Adding `aria-label` to icon-only buttons (like navigation chevrons) or visually ambiguous buttons (like `¥` which can represent CNY or JPY) is sufficient for screen readers, but sighted users relying on mouse navigation are left with no way to discover the action or disambiguate identical symbols.
+**Action:** Always complement `aria-label` on icon-only and visually ambiguous buttons with a `title` attribute to provide a native browser tooltip for sighted mouse users.

--- a/calendar/index.html
+++ b/calendar/index.html
@@ -102,22 +102,22 @@
         <nav class="container" aria-label="Main Navigation">
             <ul>
                 <li>
-                    <a href="../" aria-label="Main Site">
+                    <a href="../" aria-label="Main Site" title="Main Site">
                         <i class="fa fa-chevron-right" aria-hidden="true"></i>
                     </a>
                 </li>
                 <li>
-                    <a href="../position/" aria-label="Position">
+                    <a href="../position/" aria-label="Position" title="Position">
                         <i class="fa fa-pie-chart" aria-hidden="true"></i>
                     </a>
                 </li>
                 <li>
-                    <a href="./" aria-label="Calendar">
+                    <a href="./" aria-label="Calendar" title="Calendar">
                         <i class="fa fa-calendar" aria-hidden="true"></i>
                     </a>
                 </li>
                 <li class="hide-on-mobile">
-                    <a href="../terminal/" aria-label="Terminal">
+                    <a href="../terminal/" aria-label="Terminal" title="Terminal">
                         <i class="fa fa-code" aria-hidden="true"></i>
                     </a>
                 </li>
@@ -128,6 +128,7 @@
                 class="currency-toggle active"
                 data-currency="USD"
                 aria-label="US Dollar"
+                title="US Dollar"
                 aria-pressed="true"
             >
                 $
@@ -136,6 +137,7 @@
                 class="currency-toggle"
                 data-currency="CNY"
                 aria-label="Chinese Yuan"
+                title="Chinese Yuan"
                 aria-pressed="false"
             >
                 ¥
@@ -144,6 +146,7 @@
                 class="currency-toggle"
                 data-currency="JPY"
                 aria-label="Japanese Yen"
+                title="Japanese Yen"
                 aria-pressed="false"
             >
                 ¥
@@ -152,6 +155,7 @@
                 class="currency-toggle"
                 data-currency="KRW"
                 aria-label="South Korean Won"
+                title="South Korean Won"
                 aria-pressed="false"
             >
                 ₩
@@ -165,13 +169,28 @@
                 </div>
             </div>
             <div id="calendar-navigation-controls">
-                <button id="cal-prev" class="cal-nav-btn" aria-label="Previous Month">
+                <button
+                    id="cal-prev"
+                    class="cal-nav-btn"
+                    aria-label="Previous Month"
+                    title="Previous Month (←)"
+                >
                     <i class="fa fa-chevron-left" aria-hidden="true"></i>
                 </button>
-                <button id="cal-today" class="cal-nav-btn" aria-label="Go to Today">
+                <button
+                    id="cal-today"
+                    class="cal-nav-btn"
+                    aria-label="Go to Today"
+                    title="Go to Today (↓)"
+                >
                     <i class="fa fa-circle-o" aria-hidden="true"></i>
                 </button>
-                <button id="cal-next" class="cal-nav-btn" aria-label="Next Month">
+                <button
+                    id="cal-next"
+                    class="cal-nav-btn"
+                    aria-label="Next Month"
+                    title="Next Month (→)"
+                >
                     <i class="fa fa-chevron-right" aria-hidden="true"></i>
                 </button>
             </div>
@@ -183,6 +202,7 @@
                 target="_blank"
                 rel="noopener noreferrer"
                 aria-label="GitHub Profile"
+                title="GitHub Profile"
                 ><i class="fa fa-github" style="color: #aaa; opacity: 0.5" aria-hidden="true"></i
             ></a>
         </footer>

--- a/index.html
+++ b/index.html
@@ -74,22 +74,27 @@
         <nav class="container" aria-label="Main Navigation">
             <ul>
                 <li>
-                    <a href="https://www.lyeutsaon.com/" class="nav-link" aria-label="Main Site">
+                    <a
+                        href="https://www.lyeutsaon.com/"
+                        class="nav-link"
+                        aria-label="Main Site"
+                        title="Main Site"
+                    >
                         <i class="fa fa-chevron-right" aria-hidden="true"></i>
                     </a>
                 </li>
                 <li>
-                    <a href="./position" class="nav-link" aria-label="Position"
+                    <a href="./position" class="nav-link" aria-label="Position" title="Position"
                         ><i class="fa fa-pie-chart" aria-hidden="true"></i
                     ></a>
                 </li>
                 <li>
-                    <a href="./calendar" class="nav-link" aria-label="Calendar"
+                    <a href="./calendar" class="nav-link" aria-label="Calendar" title="Calendar"
                         ><i class="fa fa-calendar" aria-hidden="true"></i
                     ></a>
                 </li>
                 <li class="hide-on-mobile">
-                    <a href="./terminal" class="nav-link" aria-label="Terminal"
+                    <a href="./terminal" class="nav-link" aria-label="Terminal" title="Terminal"
                         ><i class="fa fa-code" aria-hidden="true"></i
                     ></a>
                 </li>
@@ -123,6 +128,7 @@
                 target="_blank"
                 rel="noopener noreferrer"
                 aria-label="GitHub Profile"
+                title="GitHub Profile"
             >
                 <i class="fa fa-github" style="color: #aaa; opacity: 0.5" aria-hidden="true"></i>
             </a>

--- a/js/ui/currencyToggleManager.js
+++ b/js/ui/currencyToggleManager.js
@@ -80,6 +80,7 @@ function applyCurrencyIcons() {
         button.textContent = '';
         button.appendChild(iconElement);
         button.setAttribute('aria-label', `${currency} currency`);
+        button.setAttribute('title', `${currency} currency`);
     });
 }
 

--- a/position/index.html
+++ b/position/index.html
@@ -79,22 +79,22 @@
         <nav class="container" aria-label="Main Navigation">
             <ul>
                 <li>
-                    <a href="../" aria-label="Main Site">
+                    <a href="../" aria-label="Main Site" title="Main Site">
                         <i class="fa fa-chevron-right" aria-hidden="true"></i>
                     </a>
                 </li>
                 <li>
-                    <a href="../position/" aria-label="Position">
+                    <a href="../position/" aria-label="Position" title="Position">
                         <i class="fa fa-pie-chart" aria-hidden="true"></i>
                     </a>
                 </li>
                 <li>
-                    <a href="../calendar/" aria-label="Calendar">
+                    <a href="../calendar/" aria-label="Calendar" title="Calendar">
                         <i class="fa fa-calendar" aria-hidden="true"></i>
                     </a>
                 </li>
                 <li class="hide-on-mobile">
-                    <a href="../terminal/" aria-label="Terminal">
+                    <a href="../terminal/" aria-label="Terminal" title="Terminal">
                         <i class="fa fa-code" aria-hidden="true"></i>
                     </a>
                 </li>
@@ -111,6 +111,7 @@
                     class="currency-toggle active"
                     data-currency="USD"
                     aria-label="US Dollar"
+                    title="US Dollar"
                     aria-pressed="true"
                 >
                     $
@@ -119,6 +120,7 @@
                     class="currency-toggle"
                     data-currency="CNY"
                     aria-label="Chinese Yuan"
+                    title="Chinese Yuan"
                     aria-pressed="false"
                 >
                     ¥
@@ -127,6 +129,7 @@
                     class="currency-toggle"
                     data-currency="JPY"
                     aria-label="Japanese Yen"
+                    title="Japanese Yen"
                     aria-pressed="false"
                 >
                     ¥
@@ -135,6 +138,7 @@
                     class="currency-toggle"
                     data-currency="KRW"
                     aria-label="South Korean Won"
+                    title="South Korean Won"
                     aria-pressed="false"
                 >
                     ₩
@@ -178,6 +182,7 @@
                 target="_blank"
                 rel="noopener noreferrer"
                 aria-label="GitHub Profile"
+                title="GitHub Profile"
                 ><i class="fa fa-github" style="color: #aaa; opacity: 0.5" aria-hidden="true"></i
             ></a>
         </footer>

--- a/terminal/index.html
+++ b/terminal/index.html
@@ -73,22 +73,22 @@
         <nav class="nav-container" aria-label="Main Navigation">
             <ul>
                 <li>
-                    <a href="../" aria-label="Main Site">
+                    <a href="../" aria-label="Main Site" title="Main Site">
                         <i class="fa fa-chevron-right" aria-hidden="true"></i>
                     </a>
                 </li>
                 <li>
-                    <a href="../position/" aria-label="Position">
+                    <a href="../position/" aria-label="Position" title="Position">
                         <i class="fa fa-pie-chart" aria-hidden="true"></i>
                     </a>
                 </li>
                 <li>
-                    <a href="../calendar/" aria-label="Calendar">
+                    <a href="../calendar/" aria-label="Calendar" title="Calendar">
                         <i class="fa fa-calendar" aria-hidden="true"></i>
                     </a>
                 </li>
                 <li>
-                    <a href="./" aria-label="Terminal">
+                    <a href="./" aria-label="Terminal" title="Terminal">
                         <i class="fa fa-code" aria-hidden="true"></i>
                     </a>
                 </li>
@@ -99,6 +99,7 @@
                 class="currency-toggle active"
                 data-currency="USD"
                 aria-label="US Dollar"
+                title="US Dollar"
                 aria-pressed="true"
             >
                 $
@@ -107,6 +108,7 @@
                 class="currency-toggle"
                 data-currency="CNY"
                 aria-label="Chinese Yuan"
+                title="Chinese Yuan"
                 aria-pressed="false"
             >
                 ¥
@@ -115,6 +117,7 @@
                 class="currency-toggle"
                 data-currency="JPY"
                 aria-label="Japanese Yen"
+                title="Japanese Yen"
                 aria-pressed="false"
             >
                 ¥
@@ -123,6 +126,7 @@
                 class="currency-toggle"
                 data-currency="KRW"
                 aria-label="South Korean Won"
+                title="South Korean Won"
                 aria-pressed="false"
             >
                 ₩
@@ -260,6 +264,7 @@
                 target="_blank"
                 rel="noopener noreferrer"
                 aria-label="GitHub Profile"
+                title="GitHub Profile"
                 ><i class="fa fa-github" style="color: #aaa; opacity: 0.5" aria-hidden="true"></i
             ></a>
         </footer>


### PR DESCRIPTION
💡 What: Added `title` attributes to visually ambiguous icon buttons (e.g., navigation menu icons and the currency toggles where the same `¥` symbol represents both Chinese Yuan and Japanese Yen) to provide native browser tooltips.
🎯 Why: `aria-label` only benefits screen readers. Sighted mouse users had no way to disambiguate the identical currency symbols or discover the meaning of the navigation icons prior to clicking.
📸 Before/After: Screenshots captured showing the native tooltip.
♿ Accessibility: Improved cognitive accessibility and usability by providing clear text labels for ambiguous iconography on hover.
📓 Journal: Updated `.jules/palette.md` with these learnings.

---
*PR created automatically by Jules for task [10255127225169804313](https://jules.google.com/task/10255127225169804313) started by @ryusoh*