### PR TITLE
⚡ Bolt: optimize marketcap chart render loops

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -262,3 +262,8 @@
 
 **Learning:** When refactoring array iteration methods (like `.forEach()`) to standard `for` loops in high-frequency rendering paths, retaining `.indexOf()` calls (e.g., `activeTickerOrder.indexOf(ticker)`) preserves an O(N) lookup.
 **Action:** Replace `.indexOf()` calls on the iterated array with the current loop's index variable (e.g., `i`) to reduce complexity to O(1) constant time, eliminating unnecessary full-array scans per iteration.
+
+## 2026-06-25 - Replaced .forEach closures in marketcap chart rendering loops
+
+**Learning:** Using `.forEach()` arrays in extremely high-frequency chart rendering loops (such as `js/transactions/chart/renderers/marketcap.js`) implicitly allocates new closure functions on every frame tick. In large composite charts with multiple overlaid lines/series, this exponentially increases the short-lived heap allocations, leading to heavy GC overhead and resulting micro-stutters during interactivity.
+**Action:** Replace `.forEach()` with explicit index-based `for` loops (e.g., `for (let c = 0; c < baseCategoryOrder.length; c += 1)`) inside critical path rendering and mapping to entirely eliminate closure creation overhead and drop GC pressure.

--- a/js/transactions/chart/renderers/marketcap.js
+++ b/js/transactions/chart/renderers/marketcap.js
@@ -123,7 +123,8 @@ function renderMarketcapChartWithMode(ctx, chartManager, data, options = {}) {
     // Get categories from data (not hardcoded) to support all categories dynamically
     const dataCategories = Object.keys(rawSeries);
 
-    dataCategories.forEach((category) => {
+    for (let c = 0; c < dataCategories.length; c += 1) {
+        const category = dataCategories[c];
         const values = rawSeries[category] || [];
         const mappedValues =
             filterFrom || filterTo
@@ -141,7 +142,7 @@ function renderMarketcapChartWithMode(ctx, chartManager, data, options = {}) {
         } else {
             chartData[category] = mappedValues;
         }
-    });
+    }
 
     // Sort categories in consistent order (defined order first, then any others by value)
     const baseCategoryOrder = [...dataCategories].sort((a, b) => {
@@ -240,7 +241,9 @@ function renderMarketcapChartWithMode(ctx, chartManager, data, options = {}) {
     );
 
     const cumulativeValues = new Array(dates.length).fill(0);
-    baseCategoryOrder.forEach((category) => {
+    // Bolt: Use standard for loop instead of .forEach to avoid closure allocation inside rendering loop
+    for (let c = 0; c < baseCategoryOrder.length; c += 1) {
+        const category = baseCategoryOrder[c];
         const values = chartData[category] || [];
         const color = resolveCategoryColor(category);
         ctx.beginPath();
@@ -248,7 +251,9 @@ function renderMarketcapChartWithMode(ctx, chartManager, data, options = {}) {
         ctx.strokeStyle = 'rgba(128, 128, 128, 0.5)';
         ctx.lineWidth = 1;
 
-        dates.forEach((dateStr, index) => {
+        // Bolt: Use standard for loop instead of .forEach to avoid closure allocation
+        for (let index = 0; index < dates.length; index += 1) {
+            const dateStr = dates[index];
             const x = xScale(parseLocalDate(dateStr).getTime());
             const y = yScale(cumulativeValues[index] + values[index]);
             if (index === 0) {
@@ -256,7 +261,7 @@ function renderMarketcapChartWithMode(ctx, chartManager, data, options = {}) {
             } else {
                 ctx.lineTo(x, y);
             }
-        });
+        }
 
         for (let i = dates.length - 1; i >= 0; i -= 1) {
             const x = xScale(parseLocalDate(dates[i]).getTime());
@@ -271,7 +276,7 @@ function renderMarketcapChartWithMode(ctx, chartManager, data, options = {}) {
         for (let i = 0; i < cumulativeValues.length; i += 1) {
             cumulativeValues[i] += values[i];
         }
-    });
+    }
 
     const latestIndex = dates.length - 1;
 


### PR DESCRIPTION
💡 What: Replaced `.forEach` loops with standard `for` loops in `js/transactions/chart/renderers/marketcap.js`.
🎯 Why: `.forEach` inside tight high-frequency rendering loops allocates new closure functions every frame, causing unnecessary garbage collection (GC) pressure and micro-stutters during interactivity.
📊 Impact: Eliminates O(N) short-lived closure allocations per frame during chart updates. Reduces GC pauses on composite view interactions.
🔬 Measurement: Verified with `pnpm run verify:all`. Can be locally profiled via Chrome DevTools during chart hover interactions to observe reduced "Minor GC" events compared to baseline.

---
*PR created automatically by Jules for task [14554711685916998023](https://jules.google.com/task/14554711685916998023) started by @ryusoh*