### PR TITLE
🛡️ Sentinel: [SECURITY ENHANCEMENT] Replace innerHTML with Safe DOM Manipulation

### DIFF
--- a/js/ui/cal-heatmap-src/plugins/Tooltip.ts
+++ b/js/ui/cal-heatmap-src/plugins/Tooltip.ts
@@ -103,9 +103,16 @@ export default class Tooltip implements IPlugin {
             const tooltipElem = document.createElement('div');
             tooltipElem.setAttribute('id', DEFAULT_SELECTOR.slice(1));
             tooltipElem.setAttribute('role', 'tooltip');
-            tooltipElem.innerHTML =
-                `<div id="${DEFAULT_SELECTOR.slice(1)}-arrow" data-popper-arrow="true"></div>` +
-                `<span id="${DEFAULT_SELECTOR.slice(1)}-body"></span>`;
+
+            const arrowElem = document.createElement('div');
+            arrowElem.setAttribute('id', `${DEFAULT_SELECTOR.slice(1)}-arrow`);
+            arrowElem.setAttribute('data-popper-arrow', 'true');
+
+            const bodyElem = document.createElement('span');
+            bodyElem.setAttribute('id', `${DEFAULT_SELECTOR.slice(1)}-body`);
+
+            tooltipElem.appendChild(arrowElem);
+            tooltipElem.appendChild(bodyElem);
 
             this.root = document.body.appendChild(tooltipElem);
         }
@@ -157,7 +164,7 @@ export default class Tooltip implements IPlugin {
         }
 
         virtualElement.getBoundingClientRect = () => e.getBoundingClientRect();
-        document.getElementById(`${DEFAULT_SELECTOR.slice(1)}-body`)!.innerHTML = title;
+        document.getElementById(`${DEFAULT_SELECTOR.slice(1)}-body`)!.textContent = title;
 
         this.popperInstance.setOptions(() => ({
             ...this.popperOptions,


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The tooltip plugin used `.innerHTML` to construct DOM nodes and inject text content, which poses a latent DOM-based XSS risk if future formatters return un-escaped HTML or user-controlled input.
🎯 Impact: Attackers could inject arbitrary scripts if the tooltip text is somehow controlled by un-sanitized external sources.
🔧 Fix: Replaced `.innerHTML` template literals with safe `document.createElement` functions and updated text assignment to use `.textContent`.
✅ Verification: Tested manually and verified by running the test suite (`pnpm run verify:all`).

---
*PR created automatically by Jules for task [10033983836699094518](https://jules.google.com/task/10033983836699094518) started by @ryusoh*