### PR TITLE
⚡ Bolt: Optimize terminal snapshots drawdown computation by eliminating .forEach closure

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -267,3 +267,8 @@
 
 **Learning:** Using `.forEach()` arrays in extremely high-frequency chart rendering loops (such as `js/transactions/chart/renderers/marketcap.js`) implicitly allocates new closure functions on every frame tick. In large composite charts with multiple overlaid lines/series, this exponentially increases the short-lived heap allocations, leading to heavy GC overhead and resulting micro-stutters during interactivity.
 **Action:** Replace `.forEach()` with explicit index-based `for` loops (e.g., `for (let c = 0; c < baseCategoryOrder.length; c += 1)`) inside critical path rendering and mapping to entirely eliminate closure creation overhead and drop GC pressure.
+
+## 2026-06-25 - Replaced .forEach closures in terminal snapshots
+
+**Learning:** Using `.forEach()` to consolidate and process large sets of data, such as mapping and storing daily drawdown entries inside `getDrawdownSnapshotLine()`, creates implicit closures for every iteration. In large datasets with hundreds or thousands of elements, this generates significant garbage collection (GC) overhead during high-frequency snapshot recalculations and terminal output renderings.
+**Action:** Replace `.forEach()` iterations over sorted records with an explicit index-based `for` loop, eliminating closure allocations entirely to lower GC pressure and ensure stable execution time.

--- a/js/transactions/terminal/snapshots.js
+++ b/js/transactions/terminal/snapshots.js
@@ -136,14 +136,15 @@ export function getDrawdownSnapshotLine({ includeHidden = false, isAbsolute = fa
 
             // Consolidate by day (keep last value)
             const dailyMap = new Map();
-            sorted.forEach((item) => {
+            for (let i = 0; i < sorted.length; i++) {
+                const item = sorted[i];
                 const d = new Date(item[dateKey] || item.date);
                 if (Number.isNaN(d.getTime())) {
-                    return;
+                    continue;
                 }
                 const dayStr = d.toISOString().split('T')[0];
                 dailyMap.set(dayStr, item);
-            });
+            }
 
             const result = new Array(dailyMap.size);
             let idx = 0;


### PR DESCRIPTION
💡 **What:** Replaced the `.forEach()` array iteration with an explicit index-based `for` loop inside the `consolidateAndSort` function within `js/transactions/terminal/snapshots.js`. It also correctly translated the early `return` to `continue`.

🎯 **Why:** Using `.forEach()` to consolidate and process large sets of data creates implicit closures for every iteration. In large datasets with hundreds or thousands of elements, this generates significant garbage collection (GC) overhead during high-frequency snapshot recalculations and terminal output renderings (like `getDrawdownSnapshotLine()`). Standard `for` loops avoid this penalty.

📊 **Impact:** Reduces GC pressure and frame drops during high-frequency updates and calculations by eliminating implicit closure allocations.

🔬 **Measurement:** Verify by running frontend tests (`npm run verify:all`), rendering the terminal snapshots, and using Chrome DevTools Performance profiler to inspect reduced closure memory allocations.

---
*PR created automatically by Jules for task [17585025779295245795](https://jules.google.com/task/17585025779295245795) started by @ryusoh*