### PR TITLE
⚡ Bolt: Replace `.forEach` closures in `cal-heatmap-src` with explicit `for` loops

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -277,3 +277,8 @@
 
 **Learning:** Using `.forEach()` with internal iterations or map setups (e.g., iterating through `keys` and `data` in `DomainCollection.ts`) creates implicit closure allocations on every call, increasing garbage collection (GC) pressure during calendar heatmap rendering.
 **Action:** Replaced nested array methods and `.forEach` with standard `for` loops rather than `.forEach` to completely eliminate intermediate array allocations and closure creation.
+
+## 2026-06-25 - Replace .forEach closures in cal-heatmap UI plugin managers and domain models
+
+**Learning:** Using `.forEach()` with internal iterations or map setups (e.g., iterating through plugin arrays in `PluginManager.ts` and collections in `DomainCollection.ts`) creates implicit closure allocations on every call, increasing garbage collection (GC) pressure during calendar heatmap rendering and high-frequency UI updates.
+**Action:** Replaced nested array methods and `.forEach` with standard explicit `for` loops in `js/ui/cal-heatmap-src/*` codes to completely eliminate intermediate array allocations and closure creations.

--- a/js/ui/cal-heatmap-src/TemplateCollection.ts
+++ b/js/ui/cal-heatmap-src/TemplateCollection.ts
@@ -41,26 +41,29 @@ export default class TemplateCollection {
         this.init();
 
         const tplWithParent: string[] = [];
-        castArray(templates).forEach((f) => {
+        const templatesArray = castArray(templates);
+        for (let i = 0; i < templatesArray.length; i++) {
+            const f = templatesArray[i];
             const template = f(this.dateHelper, this.options.options);
             this.settings.set(template.name, template);
 
             if (template.hasOwnProperty('parent')) {
                 tplWithParent.push(template.name);
             }
-        });
+        }
 
-        tplWithParent.forEach((name) => {
+        for (let i = 0; i < tplWithParent.length; i++) {
+            const name = tplWithParent[i];
             const parentTemplate = this.settings.get(this.settings.get(name)!.parent!);
 
             if (!parentTemplate) {
-                return;
+                continue;
             }
 
             this.settings.set(name, {
                 ...parentTemplate,
                 ...this.settings.get(name),
             });
-        });
+        }
     }
 }

--- a/js/ui/cal-heatmap-src/calendar/DomainCollection.ts
+++ b/js/ui/cal-heatmap-src/calendar/DomainCollection.ts
@@ -79,11 +79,21 @@ export default class DomainCollection {
 
     clamp(minDate?: Timestamp, maxDate?: Timestamp): DomainCollection {
         if (minDate && this.min! < minDate) {
-            this.keys.filter((key) => key < minDate).forEach((d) => this.collection.delete(d));
+            for (let i = 0; i < this.keys.length; i++) {
+                const key = this.keys[i];
+                if (key < minDate) {
+                    this.collection.delete(key);
+                }
+            }
         }
 
         if (maxDate && this.max! > maxDate) {
-            this.keys.filter((key) => key > maxDate).forEach((d) => this.collection.delete(d));
+            for (let i = 0; i < this.keys.length; i++) {
+                const key = this.keys[i];
+                if (key > maxDate) {
+                    this.collection.delete(key);
+                }
+            }
         }
 
         this.#refreshKeys();
@@ -94,9 +104,10 @@ export default class DomainCollection {
     merge(newCollection: DomainCollection, limit: number, createValueCallback: Function): void {
         this.yankedDomains = [];
 
-        newCollection.keys.forEach((domainKey, index) => {
+        for (let index = 0; index < newCollection.keys.length; index++) {
+            const domainKey = newCollection.keys[index];
             if (this.has(domainKey)) {
-                return;
+                continue;
             }
 
             if (this.collection.size >= limit) {
@@ -112,7 +123,7 @@ export default class DomainCollection {
             }
             this.collection.set(domainKey, createValueCallback(domainKey, index));
             this.#refreshKeys();
-        });
+        }
         this.yankedDomains = this.yankedDomains.sort((a, b) => a - b);
     }
 
@@ -122,9 +133,9 @@ export default class DomainCollection {
                 ? this.keys.slice(0, -limit)
                 : this.keys.slice(limit);
 
-            keysToDelete.forEach((key) => {
-                this.collection.delete(key);
-            });
+            for (let i = 0; i < keysToDelete.length; i++) {
+                this.collection.delete(keysToDelete[i]);
+            }
 
             this.#refreshKeys();
         }

--- a/js/ui/cal-heatmap-src/domain/DomainCoordinates.ts
+++ b/js/ui/cal-heatmap-src/domain/DomainCoordinates.ts
@@ -51,20 +51,23 @@ export default class DomainCoordinates {
             scrollFactor *= -1;
         }
 
-        collection.yankedDomains.forEach((domainKey: Timestamp) => {
+        for (let i = 0; i < collection.yankedDomains.length; i++) {
+            const domainKey = collection.yankedDomains[i];
             exitingTotal +=
                 this.collection.get(domainKey)![verticalOrientation ? 'height' : 'width'];
-        });
-        collection.yankedDomains.forEach((domainKey: Timestamp) => {
+        }
+        for (let i = 0; i < collection.yankedDomains.length; i++) {
+            const domainKey = collection.yankedDomains[i];
             const coor = this.collection.get(domainKey)!;
             this.collection.set(domainKey, {
                 ...coor,
                 x: verticalOrientation ? coor.x : coor.x + exitingTotal * scrollFactor,
                 y: verticalOrientation ? coor.y + exitingTotal * scrollFactor : coor.y,
             });
-        });
+        }
 
-        keys.forEach((domainKey: Timestamp) => {
+        for (let i = 0; i < keys.length; i++) {
+            const domainKey = keys[i];
             const w = this.#getWidth(domainKey);
             const h = this.#getHeight(domainKey);
             if (verticalOrientation) {
@@ -89,7 +92,7 @@ export default class DomainCoordinates {
                 inner_width: w - (verticalOrientation ? 0 : domain.gutter),
                 inner_height: h - (!verticalOrientation ? 0 : domain.gutter),
             });
-        });
+        }
 
         return dimensions;
     }

--- a/js/ui/cal-heatmap-src/plugins/CalendarLabel.ts
+++ b/js/ui/cal-heatmap-src/plugins/CalendarLabel.ts
@@ -140,12 +140,14 @@ export default class CalendarLabel implements IPlugin {
     }
 
     #buildComputedOptions() {
-        Object.keys(this.computedOptions).forEach((key: string) => {
+        const keys = Object.keys(this.computedOptions);
+        for (let i = 0; i < keys.length; i++) {
+            const key = keys[i];
             if (typeof this.options[key as keyof ComputedOptions] !== 'undefined') {
                 // @ts-ignore
                 this.computedOptions[key] = this.options[key];
             }
-        });
+        }
     }
 
     /**

--- a/js/ui/cal-heatmap-src/plugins/PluginManager.ts
+++ b/js/ui/cal-heatmap-src/plugins/PluginManager.ts
@@ -33,7 +33,8 @@ export default class PluginManager {
     }
 
     add(plugins: PluginDefinition[]): void {
-        plugins.forEach(([PluginClass, pluginOptions]) => {
+        for (let i = 0; i < plugins.length; i++) {
+            const [PluginClass, pluginOptions] = plugins[i];
             const name = extractPluginName(PluginClass, pluginOptions);
 
             const existingPlugin = this.plugins.get(name);
@@ -43,7 +44,7 @@ export default class PluginManager {
                 this.settings.get(name) &&
                 isEqual(this.settings.get(name)!.options, pluginOptions)
             ) {
-                return;
+                continue;
             }
 
             this.settings.set(name, {
@@ -56,11 +57,11 @@ export default class PluginManager {
             }
 
             this.pendingPaint.add(this.plugins.get(name)!);
-        });
+        }
     }
 
     setupAll(): void {
-        this.plugins.forEach((pluginInstance, name) => {
+        for (const [name, pluginInstance] of this.plugins.entries()) {
             const settings = this.settings.get(name);
 
             if (typeof settings !== 'undefined') {
@@ -71,7 +72,7 @@ export default class PluginManager {
                     this.settings.set(name, settings);
                 }
             }
-        });
+        }
     }
 
     paintAll(): Promise<unknown>[] {

--- a/js/ui/cal-heatmap-src/plugins/PluginPainter.ts
+++ b/js/ui/cal-heatmap-src/plugins/PluginPainter.ts
@@ -32,7 +32,8 @@ class PluginPainter {
         const promises: Promise<unknown>[] = [];
 
         let topOffset = 0;
-        top.forEach((plugin) => {
+        for (let i = 0; i < top.length; i++) {
+            const plugin = top[i];
             promises.push(
                 plugin.root
                     .transition()
@@ -43,10 +44,11 @@ class PluginPainter {
                     .end()
             );
             topOffset += plugin.options.dimensions!.height;
-        });
+        }
 
         let leftOffset = 0;
-        left.forEach((plugin) => {
+        for (let i = 0; i < left.length; i++) {
+            const plugin = left[i];
             promises.push(
                 plugin.root
                     .transition()
@@ -57,9 +59,10 @@ class PluginPainter {
                     .end()
             );
             leftOffset += plugin.options.dimensions!.width;
-        });
+        }
 
-        bottom.forEach((plugin) => {
+        for (let i = 0; i < bottom.length; i++) {
+            const plugin = bottom[i];
             promises.push(
                 plugin.root
                     .transition()
@@ -69,11 +72,12 @@ class PluginPainter {
                     .attr('y', topHeight + domainsContainerPainter.height())
                     .end()
             );
-        });
+        }
 
         leftOffset += domainsContainerPainter.width();
 
-        right.forEach((plugin) => {
+        for (let i = 0; i < right.length; i++) {
+            const plugin = right[i];
             promises.push(
                 plugin.root
                     .transition()
@@ -84,7 +88,7 @@ class PluginPainter {
                     .end()
             );
             leftOffset += plugin.options.dimensions!.width;
-        });
+        }
 
         return promises;
     }

--- a/js/ui/cal-heatmap-src/scale.ts
+++ b/js/ui/cal-heatmap-src/scale.ts
@@ -45,11 +45,12 @@ export function applyScaleStyle(
     scaleOptions: OptionsType['scale'],
     keyname?: string
 ) {
-    Object.entries(scaleStyle(_scale, scaleOptions)).forEach(([prop, val]) =>
-        // eslint-disable-next-line implicit-arrow-linebreak
+    const entries = Object.entries(scaleStyle(_scale, scaleOptions));
+    for (let i = 0; i < entries.length; i++) {
+        const [prop, val] = entries[i];
         elem.style(prop, (d: SubDomain | string) =>
             // eslint-disable-next-line implicit-arrow-linebreak
-            val(keyname ? (d as SubDomain)[keyname as keyof SubDomain] : d)
-        )
-    );
+            (val as Function)(keyname ? (d as SubDomain)[keyname as keyof SubDomain] : d)
+        );
+    }
 }

--- a/js/ui/cal-heatmap-src/subDomain/SubDomainPainter.ts
+++ b/js/ui/cal-heatmap-src/subDomain/SubDomainPainter.ts
@@ -48,9 +48,10 @@ export default class SubDomainPainter {
                 const subDomainsCollection: SubDomain[] = this.calendar.domainCollection.get(d)!;
                 if (sort === 'desc') {
                     const max = Math.max(...subDomainsCollection.map((s: SubDomain) => s.x));
-                    subDomainsCollection.forEach((s: SubDomain, i: number) => {
+                    for (let i = 0; i < subDomainsCollection.length; i++) {
+                        const s = subDomainsCollection[i];
                         subDomainsCollection[i].x = Math.abs(s.x - max);
-                    });
+                    }
                 }
 
                 return subDomainsCollection;
@@ -144,13 +145,14 @@ export default class SubDomainPainter {
         let classname = '';
 
         if (highlight.length > 0) {
-            highlight.forEach((d) => {
+            for (let i = 0; i < highlight.length; i++) {
+                const d = highlight[i];
                 const unitFn = this.calendar.templateCollection.get(type).extractUnit;
 
                 if (unitFn(+d) === unitFn(timestamp)) {
                     classname = HIGHLIGHT_CLASSNAME;
                 }
-            });
+            }
         }
 
         return [classname, ...otherClasses].join(' ').trim();


### PR DESCRIPTION
💡 What: Replaced all `.forEach` array iterations with explicit `for` loops in the core `cal-heatmap-src` library (specifically domain and plugin managers).
🎯 Why: Iterating with `.forEach()` inside rendering, positioning, and data updating logic implicitly allocates closure functions on every tick. This compounding closure creation generates high garbage collection (GC) overhead during heatmap interaction or dynamic updates.
📊 Impact: Eliminates a major source of closure allocations during the component's data binding and paint cycles, decreasing memory thrash and smoothing UI interactions on large datasets.
🔬 Measurement: Verify stable frame rates and decreased GC pause time using Chrome DevTools Performance profile when interacting with or paginating the calendar heatmap.

---
*PR created automatically by Jules for task [3351643434083158910](https://jules.google.com/task/3351643434083158910) started by @ryusoh*