### PR TITLE
TestPilot: Improve test coverage for Analysis Lab and Composition Chart edge cases

### DIFF
--- a/.jules/testpilot.md
+++ b/.jules/testpilot.md
@@ -112,3 +112,8 @@ To test highly internal functions isolated in a module closure safely, we inject
 ## 2025-02-14 - Test Analysis Snapshot
 
 **Learning:** For rendering complex ascii tables with combinations of open vs closed positions, ensure you use accurate map references in Jest to properly track function calls. When utilizing mocked imported functions inside Jest unit tests covering pure text rendering (such as `getDurationStatsText` or `getLifespanStatsText`), mock local formatting utils appropriately to simulate exact string combinations.
+
+## 2024-06-25 - DOM Event Handlers Mocking
+
+**Learning:** When unit testing scripts that expect specific DOM elements to attach event listeners to during initialization (like lab.js attaching to btnRunMonteCarlo), ensure all expected elements are present in document.body.innerHTML before require()-ing the module. Failing to do so causes TypeError: Cannot read properties of null (reading addEventListener).
+**Action:** Added tests for MonteCarlo and Bayes DOM event handlers.

--- a/tests/js/pages/analysis/lab_coverage.test.js
+++ b/tests/js/pages/analysis/lab_coverage.test.js
@@ -1,0 +1,163 @@
+global.Worker = class {
+    constructor(stringUrl) {
+        this.url = stringUrl;
+        this.onmessage = () => {};
+    }
+    postMessage(msg) {
+        this.onmessage(msg);
+    }
+};
+
+const FLAG = '__SKIP_ANALYSIS_AUTO_INIT__';
+global[FLAG] = true;
+
+// Mock the DOM elements expected by lab.js
+document.body.innerHTML = `
+    <button id="btnBayesBull"></button>
+    <button id="btnBayesNeutral"></button>
+    <button id="btnBayesBear"></button>
+    <button id="btnBayesReset"></button>
+    <button id="btnRunMonteCarlo"></button>
+`;
+
+const { __analysisLabTesting } = require('../../../../js/pages/analysis/lab.js');
+
+describe('lab.js specific coverage', () => {
+    describe('normalizeConfig additional branch coverage', () => {
+        it('normalizes risk volatility if not finite', () => {
+            const raw = {
+                symbol: 'TEST',
+                risk: { volatility: 'invalid' },
+                scenarios: [],
+            };
+            const result = __analysisLabTesting.normalizeConfig(raw);
+            expect(result.risk.volatility).toBeUndefined();
+        });
+
+        it('normalizes number override values and skips invalid ones', () => {
+            const raw = {
+                symbol: 'TEST',
+                scenarios: [],
+                manual: { price: '100', eps: 'invalid', volatility: null },
+            };
+            const result = __analysisLabTesting.normalizeConfig(raw);
+            expect(result.model.preferences.overrides.price).toBe(100);
+            expect(result.model.preferences.overrides.eps).toBeUndefined();
+            expect(result.model.preferences.overrides.volatility).toBeUndefined();
+        });
+
+        it('assigns overrides when legacy values are not defined', () => {
+            const raw = {
+                symbol: 'TEST',
+                scenarios: [],
+                model: {
+                    preferences: {
+                        overrides: { price: 200, eps: 10, volatility: 0.25 },
+                    },
+                },
+            };
+            const result = __analysisLabTesting.normalizeConfig(raw);
+            expect(result.model.preferences.overrides.price).toBe(200);
+            expect(result.model.preferences.overrides.eps).toBe(10);
+            expect(result.model.preferences.overrides.volatility).toBe(0.25);
+        });
+
+        it('assigns overrides and skips if not finite', () => {
+            const raw = {
+                symbol: 'TEST',
+                scenarios: [],
+                model: {
+                    preferences: {
+                        overrides: { price: 'invalid', eps: 'foo' },
+                    },
+                },
+            };
+            const result = __analysisLabTesting.normalizeConfig(raw);
+            expect(result.model.preferences.overrides.price).toBeUndefined();
+            expect(result.model.preferences.overrides.eps).toBeUndefined();
+        });
+    });
+
+    describe('buildPortfolioConfig additional branch coverage', () => {
+        it('handles when Kelly scale is missing from preferences', () => {
+            const cfg1 = {
+                marketValue: 1000,
+                weight: 1,
+                scenarios: [],
+                model: {
+                    preferences: { targetCagr: 0.1, benchmark: { value: 100 } }, // No kellyScale
+                },
+                risk: { volatility: 0.2 },
+                market: { price: 100 },
+                position: { shares: 10 },
+                metrics: { outcomes: [{ id: 'base', name: 'Base', prob: 0.5, earningsCagr: 0.1 }] },
+            };
+
+            const portfolio = __analysisLabTesting.buildPortfolioConfig([cfg1]);
+            // It should fallback to 0.5 for missing kellyScale
+            expect(portfolio.model.preferences.kellyScale).toBeCloseTo(0.5);
+        });
+    });
+});
+
+    describe('aggregateScenarios additional branch coverage', () => {
+        it('handles missing or zero holding weight', () => {
+            const configs = [
+                {
+                    weight: 0,
+                    metrics: {
+                        outcomes: [
+                            { id: 'base', name: 'Base', multiple: 1.4, prob: 0.4, earningsCagr: 0.1 },
+                        ],
+                    },
+                },
+                {
+                    weight: 1,
+                    metrics: {
+                        outcomes: [
+                            { id: 'base', name: 'Base', multiple: 2.0, prob: 0.3, earningsCagr: 0.25 },
+                        ],
+                    },
+                }
+            ];
+            const scenarios = __analysisLabTesting.aggregateScenarios(configs, 4);
+            const baseScenario = scenarios.find((scenario) => scenario.id === 'base');
+
+            // Only the second config should be counted
+            expect(baseScenario.precomputedMultiple).toBeCloseTo(2.0);
+        });
+
+        it('handles missing outcome IDs and computes price CAGR appropriately', () => {
+            const configs = [
+                {
+                    weight: 1,
+                    metrics: {
+                        outcomes: [
+                            { name: 'Unknown', multiple: 1.5, prob: 1.0 }, // No id, No earningsCagr
+                        ],
+                    },
+                }
+            ];
+
+            const scenarios = __analysisLabTesting.aggregateScenarios(configs, 2);
+            expect(scenarios[0].id).toBe('Unknown');
+            expect(scenarios[0].precomputedEarningsCagr).toBeNull();
+            expect(scenarios[0].precomputedCagr).toBeCloseTo(Math.pow(1.5, 0.5) - 1);
+        });
+
+        it('handles zero horizon', () => {
+            const configs = [
+                {
+                    weight: 1,
+                    metrics: {
+                        outcomes: [
+                            { id: 'base', name: 'Base', multiple: 1.5, prob: 1.0 },
+                        ],
+                    },
+                }
+            ];
+
+            const scenarios = __analysisLabTesting.aggregateScenarios(configs, 0);
+            expect(scenarios[0].precomputedCagr).toBe(0);
+        });
+    });

--- a/tests/js/pages/analysis/lab_dom.test.js
+++ b/tests/js/pages/analysis/lab_dom.test.js
@@ -1,0 +1,95 @@
+global.Worker = class {
+    constructor(stringUrl) {
+        this.url = stringUrl;
+        this.onmessage = () => {};
+    }
+    postMessage(msg) {
+        this.onmessage({ data: msg });
+    }
+};
+
+const FLAG = '__SKIP_ANALYSIS_AUTO_INIT__';
+global[FLAG] = true;
+
+// Mock the DOM elements expected by lab.js
+document.body.innerHTML = `
+    <div id="bayesOutput"></div>
+    <button id="btnBayesBull"></button>
+    <button id="btnBayesNeutral"></button>
+    <button id="btnBayesBear"></button>
+    <button id="btnBayesReset"></button>
+    <button id="btnRunMonteCarlo"></button>
+`;
+
+const { __analysisLabTesting } = require('../../../../js/pages/analysis/lab.js');
+
+describe('lab.js DOM event coverage', () => {
+    let mockBayesEngine;
+
+    beforeEach(() => {
+        mockBayesEngine = {
+            update: jest.fn(),
+            reset: jest.fn(),
+            priors: [
+                { name: 'Bull', prob: 0.5 },
+                { name: 'Bear', prob: 0.5 },
+            ],
+        };
+        __analysisLabTesting.state.bayesEngine = mockBayesEngine;
+        __analysisLabTesting.state.configs = [
+            {
+                symbol: 'TEST',
+                scenarios: [],
+                metrics: { price: 100, eps: 5, volatility: 0.2, horizon: 5 },
+            },
+        ];
+        __analysisLabTesting.state.activeSymbol = 'TEST';
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('btnBayesBull click updates engine and renders', () => {
+        const btn = document.getElementById('btnBayesBull');
+        btn.click();
+        expect(mockBayesEngine.update).toHaveBeenCalledWith('bullish', 0.6);
+        // Checking if render was called by verifying the DOM output
+        const output = document.getElementById('bayesOutput');
+        expect(output.textContent).toContain('Bull50.0%');
+    });
+
+    it('btnBayesBear click updates engine and renders', () => {
+        const btn = document.getElementById('btnBayesBear');
+        btn.click();
+        expect(mockBayesEngine.update).toHaveBeenCalledWith('bearish', 0.6);
+        const output = document.getElementById('bayesOutput');
+        expect(output.textContent).toContain('Bear50.0%');
+    });
+
+    it('btnBayesReset click resets engine and renders', () => {
+        const btn = document.getElementById('btnBayesReset');
+        btn.click();
+        expect(mockBayesEngine.reset).toHaveBeenCalledWith([]);
+        const output = document.getElementById('bayesOutput');
+        expect(output.textContent).toContain('Bull50.0%');
+    });
+
+    it('btnRunMonteCarlo click posts message to worker', () => {
+        const btn = document.getElementById('btnRunMonteCarlo');
+        const postMessageSpy = jest.spyOn(
+            __analysisLabTesting.state.monteCarloWorker,
+            'postMessage'
+        );
+
+        btn.click();
+
+        expect(btn.disabled).toBe(true);
+        expect(btn.textContent).toContain('Running...');
+        expect(postMessageSpy).toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: 'RUN_SIMULATION',
+            })
+        );
+    });
+});

--- a/tests/js/transactions/chart/renderers/composition_coverage.test.js
+++ b/tests/js/transactions/chart/renderers/composition_coverage.test.js
@@ -1,0 +1,136 @@
+import {
+    drawCompositionChart,
+    drawCompositionAbsoluteChart,
+} from '../../../../../js/transactions/chart/renderers/composition.js';
+import { loadCompositionSnapshotData } from '../../../../../js/transactions/dataLoader.js';
+
+jest.mock('../../../../../js/utils/logger.js', () => ({
+    logger: {
+        warn: jest.fn(),
+        info: jest.fn(),
+        error: jest.fn(),
+    },
+}));
+
+jest.mock('../../../../../js/transactions/state.js', () => ({
+    transactionState: {
+        activeChart: 'composition',
+    },
+    getCompositionFilterTickers: jest.fn().mockReturnValue([]),
+    getCompositionAssetClassFilter: jest.fn().mockReturnValue(''),
+}));
+
+jest.mock('../../../../../js/transactions/chart/state.js', () => ({
+    chartLayouts: {
+        composition: null,
+        compositionAbs: null,
+    },
+}));
+
+jest.mock('../../../../../js/transactions/dataLoader.js', () => ({
+    loadCompositionSnapshotData: jest.fn(),
+}));
+
+jest.mock('../../../../../js/transactions/chart/animation.js', () => ({
+    stopPerformanceAnimation: jest.fn(),
+    stopContributionAnimation: jest.fn(),
+    stopFxAnimation: jest.fn(),
+}));
+
+jest.mock('../../../../../js/transactions/chart/interaction.js', () => ({
+    updateCrosshairUI: jest.fn(),
+    updateLegend: jest.fn(),
+    drawCrosshairOverlay: jest.fn(),
+}));
+
+jest.mock('../../../../../js/transactions/chart/core.js', () => ({
+    drawAxes: jest.fn(),
+}));
+
+jest.mock('../../../../../js/transactions/chart/helpers.js', () => ({
+    createTimeInterpolator: jest.fn(),
+    clampTime: jest.fn(),
+    formatPercentInline: jest.fn(),
+    parseLocalDate: jest.fn(),
+}));
+
+jest.mock('../../../../../js/transactions/utils.js', () => ({
+    formatCurrencyInlineValue: jest.fn(),
+    formatCurrencyCompact: jest.fn(),
+    convertValueToCurrency: jest.fn(),
+}));
+
+describe('drawCompositionChart', () => {
+    let ctxMock;
+    let chartManagerMock;
+    let emptyStateMock;
+
+    beforeEach(() => {
+        ctxMock = {
+            canvas: { width: 800, height: 600, style: {} },
+            save: jest.fn(),
+            restore: jest.fn(),
+            beginPath: jest.fn(),
+            moveTo: jest.fn(),
+            lineTo: jest.fn(),
+            fill: jest.fn(),
+            stroke: jest.fn(),
+            clip: jest.fn(),
+            clearRect: jest.fn(),
+        };
+        chartManagerMock = {
+            canvas: { width: 800, height: 600, style: {} },
+        };
+
+        emptyStateMock = { style: { display: 'none' } };
+        jest.spyOn(document, 'getElementById').mockReturnValue(emptyStateMock);
+        loadCompositionSnapshotData.mockClear();
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('should show empty state if composition data fails to load', async () => {
+        loadCompositionSnapshotData.mockRejectedValueOnce(new Error('Network error'));
+
+        drawCompositionChart(ctxMock, chartManagerMock);
+
+        // Wait for next tick so promise rejection is handled
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect(emptyStateMock.style.display).toBe('block');
+    });
+
+    it('should handle falsy data from data loader', async () => {
+        loadCompositionSnapshotData.mockResolvedValueOnce(null);
+
+        drawCompositionChart(ctxMock, chartManagerMock);
+
+        // Wait for next tick so promise rejection is handled
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect(emptyStateMock.style.display).toBe('block');
+    });
+
+    it('should handle invalid data structure', async () => {
+        loadCompositionSnapshotData.mockResolvedValueOnce({ invalid: 'data' });
+
+        drawCompositionChart(ctxMock, chartManagerMock);
+
+        // Wait for next tick so promise is handled
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect(emptyStateMock.style.display).toBe('block');
+    });
+
+    it('should handle absolute mode with falsy data', async () => {
+        loadCompositionSnapshotData.mockResolvedValueOnce(null);
+
+        drawCompositionAbsoluteChart(ctxMock, chartManagerMock);
+
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect(emptyStateMock.style.display).toBe('block');
+    });
+});


### PR DESCRIPTION
As the TestPilot agent, this PR addresses exactly three distinct areas of missing or inadequate test coverage.

**Areas Targeted:**
1. `js/pages/analysis/lab.js` - Configuration parsing fallback branches (`normalizeConfig`, `buildPortfolioConfig`).
2. `js/pages/analysis/lab.js` - DOM Event Handlers (`btnRunMonteCarlo`, `btnBayesBull`, etc.) interacting with `Worker` dependencies.
3. `js/transactions/chart/renderers/composition.js` - Network failure logic (`loadCompositionSnapshotData` rejecting/returning null) forcing the UI into an empty state.

**Key Features of the Tests:**
* Mocked global variables like `Worker` and correctly populated `document.body.innerHTML` before loading scripts that self-initialize on import.
* Fully mocked internal function imports and application `state.js` variables to properly isolate the `Arrange-Act-Assert` cycle.
* Added specific learnings about unit testing event listener injection to `.jules/testpilot.md` using append mode.
* Verified that the entire test suite still fully passes locally (`pnpm run verify:all`).

---
*PR created automatically by Jules for task [7060556820198084592](https://jules.google.com/task/7060556820198084592) started by @ryusoh*