### PR TITLE
⚡ Bolt: optimize cal-heatmap plugin dimension calculations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -302,3 +302,7 @@
 
 **Learning:** Using `.forEach()` in table parsing routines (like `parseCommandPalette`) and high-frequency chart drawing components (like `drawContributionMarkers` and `drawVolumeChart`) creates implicit closure allocations for each element iterated. These allocations generate significant garbage collection (GC) pressure that leads to micro-stutters during interactions, filtering, and chart renderings.
 **Action:** Replaced `.forEach()` in `js/transactions/chart/renderers/contributionComponents.js` and `js/transactions/table/parser.js` with explicit, index-based `for` loops and `for...of` loops for Maps to completely eliminate intermediate closure creations and dramatically reduce GC overhead.
+## 2026-06-25 - Replace chained .map().reduce() with explicit for loops
+
+**Learning:** Using `.map().reduce()` chains inside classes or modules to accumulate properties from an array of objects (like calculating total width/height of plugins) generates intermediate arrays and closure functions on every execution, increasing garbage collection (GC) pressure.
+**Action:** Replace these higher-order array chains with an explicit `for` loop that iterates over the original array and accumulates the value directly (e.g., `let total = 0; for (let i = 0; i < arr.length; i++) { total += arr[i].val; }`).

--- a/js/ui/cal-heatmap-src/plugins/PluginManager.ts
+++ b/js/ui/cal-heatmap-src/plugins/PluginManager.ts
@@ -92,15 +92,21 @@ export default class PluginManager {
     }
 
     getHeightFromPosition(position: PluginOptions['position']): number {
-        return this.getFromPosition(position)
-            .map((d) => d.options.dimensions!.height)
-            .reduce((a, b) => a + b, 0);
+        const plugins = this.getFromPosition(position);
+        let height = 0;
+        for (let i = 0; i < plugins.length; i++) {
+            height += plugins[i].options.dimensions!.height;
+        }
+        return height;
     }
 
     getWidthFromPosition(position: PluginOptions['position']): number {
-        return this.getFromPosition(position)
-            .map((d) => d.options.dimensions!.width)
-            .reduce((a, b) => a + b, 0);
+        const plugins = this.getFromPosition(position);
+        let width = 0;
+        for (let i = 0; i < plugins.length; i++) {
+            width += plugins[i].options.dimensions!.width;
+        }
+        return width;
     }
 
     allPlugins(): IPlugin[] {


### PR DESCRIPTION
💡 What: Replaced `.map().reduce()` chains in `js/ui/cal-heatmap-src/plugins/PluginManager.ts` with standard `for` loops.
🎯 Why: Using chained array higher-order methods like `.map()` and `.reduce()` inside layout calculation functions generates unnecessary intermediate arrays and invokes closure functions on each element, slightly increasing garbage collection pressure.
📊 Impact: Eliminates the O(N) intermediate array allocation and avoids closure allocation per layout fetch, reducing heap overhead and GC load during frequent heatmap layouts.
🔬 Measurement: Code review to ensure that `for` loops accumulate the width and height directly.

---
*PR created automatically by Jules for task [2244286705383127294](https://jules.google.com/task/2244286705383127294) started by @ryusoh*