### PR TITLE
⚡ Bolt: Replace .forEach closures in contribution data processing loops

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -306,3 +306,8 @@
 
 **Learning:** Using `.map().reduce()` chains inside classes or modules to accumulate properties from an array of objects (like calculating total width/height of plugins) generates intermediate arrays and closure functions on every execution, increasing garbage collection (GC) pressure.
 **Action:** Replace these higher-order array chains with an explicit `for` loop that iterates over the original array and accumulates the value directly (e.g., `let total = 0; for (let i = 0; i < arr.length; i++) { total += arr[i].val; }`).
+
+## 2026-06-25 - Replace .forEach closures in contribution data processing loops
+
+**Learning:** Using `.forEach()` with callbacks inside high-frequency data construction paths, such as accumulating transaction metrics, resolving stock splits, and computing filtered balance series in `js/transactions/chart/data/contribution.js`, forces implicit closure allocations and callback overhead per iteration. For portfolios containing thousands of transaction records or numerous unique dates, this creates measurable garbage collection (GC) pressure that can drop frames when charts render dynamically.
+**Action:** Replace `.forEach()` iterations with standard explicitly-indexed `for` loops (e.g. `for (let i = 0; i < sortedTransactions.length; i++)`) and `for...of` iteration on Map instances (e.g. `for (const [symbol, qty] of holdings.entries())`) to entirely eliminate closures and array-method overhead during chart data preparation.

--- a/js/transactions/chart/data/contribution.js
+++ b/js/transactions/chart/data/contribution.js
@@ -61,7 +61,8 @@ export function buildContributionSeriesFromTransactions(
 
     // Consolidate transactions by date
     const dailyMap = new Map();
-    sortedTransactions.forEach((t) => {
+    for (let i = 0; i < sortedTransactions.length; i++) {
+        const t = sortedTransactions[i];
         const dateStr = t.tradeDate;
         if (!dailyMap.has(dateStr)) {
             dailyMap.set(dateStr, {
@@ -82,7 +83,7 @@ export function buildContributionSeriesFromTransactions(
         } else if (type === 'sell') {
             entry.sellVolume += Math.abs(amount);
         }
-    });
+    }
 
     // Bolt: Replaced Array.from(dailyMap.keys()).sort() with explicit pre-allocated array and manual iteration to reduce GC overhead
     const uniqueDates = new Array(dailyMap.size);
@@ -95,7 +96,8 @@ export function buildContributionSeriesFromTransactions(
     const series = [];
     let cumulativeAmount = 0;
 
-    uniqueDates.forEach((dateStr, index) => {
+    for (let index = 0; index < uniqueDates.length; index++) {
+        const dateStr = uniqueDates[index];
         const entry = dailyMap.get(dateStr);
         const netDelta = entry.netAmount;
 
@@ -155,7 +157,7 @@ export function buildContributionSeriesFromTransactions(
             buyVolume: entry.buyVolume,
             sellVolume: entry.sellVolume,
         });
-    });
+    }
 
     const lastPoint = series[series.length - 1];
     if (lastPoint) {
@@ -298,9 +300,11 @@ export function buildFilteredBalanceSeries(transactions, historicalPrices, split
     const lastDate = today > lastTransactionDate ? today : lastTransactionDate;
 
     const splitsByDate = new Map();
-    (Array.isArray(splitHistory) ? splitHistory : []).forEach((split) => {
+    const splitArr = Array.isArray(splitHistory) ? splitHistory : [];
+    for (let i = 0; i < splitArr.length; i++) {
+        const split = splitArr[i];
         if (!split || !split.splitDate || !split.symbol) {
-            return;
+            continue;
         }
         const dateKey = new Date(split.splitDate).toISOString().split('T')[0];
         const multiplier = Number(split.splitMultiplier) || Number(split.split_multiplier) || 1;
@@ -309,16 +313,17 @@ export function buildFilteredBalanceSeries(transactions, historicalPrices, split
             splitsByDate.set(dateKey, []);
         }
         splitsByDate.get(dateKey).push({ symbol: symbolKey, multiplier });
-    });
+    }
 
     const transactionsByDate = new Map();
-    sortedTransactions.forEach((txn) => {
+    for (let i = 0; i < sortedTransactions.length; i++) {
+        const txn = sortedTransactions[i];
         const dateStr = new Date(txn.tradeDate).toISOString().split('T')[0];
         if (!transactionsByDate.has(dateStr)) {
             transactionsByDate.set(dateStr, []);
         }
         transactionsByDate.get(dateStr).push(txn);
-    });
+    }
 
     const holdings = new Map();
     const lastKnownPrices = new Map(); // Track last known price from transactions
@@ -333,9 +338,10 @@ export function buildFilteredBalanceSeries(transactions, historicalPrices, split
 
         const splitsToday = splitsByDate.get(dateStr);
         if (splitsToday) {
-            splitsToday.forEach(({ symbol, multiplier }) => {
+            for (let i = 0; i < splitsToday.length; i++) {
+                const { symbol, multiplier } = splitsToday[i];
                 if (!Number.isFinite(multiplier) || multiplier <= 0) {
-                    return;
+                    continue;
                 }
                 const currentQty = holdings.get(symbol);
                 if (currentQty !== undefined) {
@@ -346,16 +352,17 @@ export function buildFilteredBalanceSeries(transactions, historicalPrices, split
                 if (lastPrice !== undefined && multiplier > 0) {
                     lastKnownPrices.set(symbol, lastPrice / multiplier);
                 }
-            });
+            }
         }
 
         const todaysTransactions = transactionsByDate.get(dateStr) || [];
-        todaysTransactions.forEach((txn) => {
+        for (let i = 0; i < todaysTransactions.length; i++) {
+            const txn = todaysTransactions[i];
             const normalizedSymbol = normalizeSymbolForPricing(txn.security);
             const quantity = parseFloat(txn.quantity) || 0;
             const txnPrice = parseFloat(txn.price);
             if (!Number.isFinite(quantity) || quantity === 0) {
-                return;
+                continue;
             }
             // Update last known price from this transaction
             if (Number.isFinite(txnPrice) && txnPrice > 0) {
@@ -369,12 +376,12 @@ export function buildFilteredBalanceSeries(transactions, historicalPrices, split
             } else {
                 holdings.set(normalizedSymbol, updatedQty);
             }
-        });
+        }
 
         let totalValue = 0;
-        holdings.forEach((qty, symbol) => {
+        for (const [symbol, qty] of holdings.entries()) {
             if (!Number.isFinite(qty) || Math.abs(qty) < 1e-8) {
-                return;
+                continue;
             }
             let price = getPriceFromHistoricalData(historicalPrices, symbol, dateStr);
             // Fallback to last known transaction price if historical price unavailable
@@ -382,11 +389,11 @@ export function buildFilteredBalanceSeries(transactions, historicalPrices, split
                 price = lastKnownPrices.get(symbol) ?? null;
             }
             if (price === null) {
-                return;
+                continue;
             }
             const adjustment = getSplitAdjustment(splitHistory, symbol, dateStr);
             totalValue += qty * price * adjustment;
-        });
+        }
 
         series.push({ date: dateStr, value: totalValue });
         iterDate.setDate(iterDate.getDate() + 1);


### PR DESCRIPTION
💡 What: Replaced array `.forEach` closures with standard explicit `for` loops and `for...of` iterator loops in `js/transactions/chart/data/contribution.js`.
🎯 Why: Using `.forEach()` with callbacks inside high-frequency data construction paths, such as accumulating transaction metrics, resolving stock splits, and computing filtered balance series, forces implicit closure allocations and callback overhead per iteration. This creates measurable GC pressure that can drop frames when charts render dynamically.
📊 Impact: Entirely eliminates closure and array-method overhead during chart data preparation, leading to fewer GC pauses and smoother visual updates for portfolios with thousands of transactions or unique dates.
🔬 Measurement: Verify using `npm run verify:all` and performance profiling in Chrome DevTools to observe reduced GC pressure during heavy data manipulation operations.

---
*PR created automatically by Jules for task [13378710687447527165](https://jules.google.com/task/13378710687447527165) started by @ryusoh*