### PR TITLE
Typist: strict-type js/utils/easing.js

### DIFF
--- a/.jules/typist.md
+++ b/.jules/typist.md
@@ -1,0 +1,5 @@
+
+## 2026-06-23 - js/utils/easing.js
+**Issue:** Missing type annotation for parameter `x` in `easeInOutSine` function, causing TS7006 under strict mode.
+**Action:** Added JSDoc `@param {number} x` and `@returns {number}` to strongly type the mathematical operation.
+**Verification:** `npx tsc -p jsconfig.json --strict` error count decreased by 1. Lint, formatting, and unit tests are green.

--- a/js/utils/easing.js
+++ b/js/utils/easing.js
@@ -1,4 +1,8 @@
 // Easing function for smoother animations
+/**
+ * @param {number} x
+ * @returns {number}
+ */
 export function easeInOutSine(x) {
     const val = -(Math.cos(Math.PI * x) - 1) / 2;
     return val === 0 ? 0 : val;


### PR DESCRIPTION
This PR strict-types `js/utils/easing.js` by adding JSDoc comments to resolve the `implicit any` TypeScript warning. 
No runtime logic was changed. `npx tsc -p jsconfig.json --strict` error count successfully decreased. 

Fixes TS7006. Log appended in `.jules/typist.md`.

---
*PR created automatically by Jules for task [13704056416711318201](https://jules.google.com/task/13704056416711318201) started by @ryusoh*