### PR TITLE
refactor(types): annotate assetClasses.js for strict mode

### DIFF
--- a/js/config/assetClasses.js
+++ b/js/config/assetClasses.js
@@ -1,3 +1,4 @@
+/** @type {Record<string, string>} */
 export const ASSET_CLASS_OVERRIDES = {
     // Broad market ETFs / funds
     VT: 'etf',
@@ -112,6 +113,10 @@ export const ASSET_CLASS_OVERRIDES = {
     VTPSX: 'etf',
 };
 
+/**
+ * @param {unknown} ticker
+ * @returns {boolean}
+ */
 export function isLikelyFundTicker(ticker) {
     if (typeof ticker !== 'string') {
         return false;


### PR DESCRIPTION
Adds JSDoc type annotations to `js/config/assetClasses.js` to satisfy TypeScript strict-mode checking. The `isLikelyFundTicker` function has been annotated with `@param {unknown} ticker` and `@returns {boolean}`, and `ASSET_CLASS_OVERRIDES` with `@type {Record<string, string>}`.

No runtime logic was changed. Strict error count on the target file dropped to 0, and `make verify` continues to pass green.

---
*PR created automatically by Jules for task [300100332236832402](https://jules.google.com/task/300100332236832402) started by @ryusoh*