### PR TITLE
perf(chart): replace .forEach with for loops in hot rendering paths

### DIFF
--- a/js/transactions/chart/core.js
+++ b/js/transactions/chart/core.js
@@ -210,7 +210,8 @@ export function generateYearBasedTicks(minTime, maxTime) {
             { month: 9, label: 'Oct', isYearStart: false },
         ];
 
-        quarters.forEach((q) => {
+        for (let i = 0; i < quarters.length; i++) {
+            const q = quarters[i];
             const quarterDate = new Date(year, q.month, 1).getTime();
             // Always include quarterly ticks for the year, even if slightly outside the range
             if (
@@ -223,7 +224,7 @@ export function generateYearBasedTicks(minTime, maxTime) {
                     isYearStart: q.isYearStart,
                 });
             }
-        });
+        }
 
         // If data spans into a new year and primary year is the start year,
         // add a tick at Jan 1 of the new year so the year label appears at the year boundary
@@ -347,7 +348,8 @@ export function drawAxes(
     if (drawYAxis) {
         const fontSize = isMobile ? 9 : 11;
         const halfTextHeight = fontSize / 2;
-        ticks.forEach((value) => {
+        for (let i = 0; i < ticks.length; i++) {
+            const value = ticks[i];
             const y = yScale(value);
             ctx.beginPath();
             ctx.moveTo(padding.left, y);
@@ -361,7 +363,7 @@ export function drawAxes(
             const wouldClipTop = y - halfTextHeight < 2;
             ctx.textBaseline = wouldClipTop ? 'top' : 'middle';
             ctx.fillText(yLabelFormatter(value), padding.left - (isMobile ? 8 : 10), y);
-        });
+        }
     }
 
     // X-axis line
@@ -383,7 +385,8 @@ export function drawAxes(
         ctx.font = isMobile ? `9px ${monoFont}` : `11px ${monoFont}`;
     }
 
-    yearTicks.forEach((tick, index) => {
+    for (let index = 0; index < yearTicks.length; index++) {
+        const tick = yearTicks[index];
         const x = xScale(tick.time);
 
         // Check for label collision (Desktop & Mobile)
@@ -452,7 +455,7 @@ export function drawAxes(
                 ctx.setLineDash([]); // Reset to solid line
             }
         }
-    });
+    }
 }
 
 export function drawMountainFill(ctx, coords, baselineY, options) {
@@ -521,10 +524,11 @@ export function drawMountainFill(ctx, coords, baselineY, options) {
     if (Array.isArray(colorStops) && colorStops.length > 0) {
         horizontalGradient = offCtx.createLinearGradient(0, 0, width, 0);
         const stopCount = colorStops.length;
-        colorStops.forEach((stopColor, index) => {
+        for (let index = 0; index < stopCount; index++) {
+            const stopColor = colorStops[index];
             const offset = stopCount === 1 ? 0 : index / (stopCount - 1);
             horizontalGradient.addColorStop(offset, colorWithAlpha(stopColor, 1));
-        });
+        }
     }
 
     if (horizontalGradient) {

--- a/js/transactions/chart/renderers/volatility.js
+++ b/js/transactions/chart/renderers/volatility.js
@@ -56,11 +56,12 @@ export async function drawVolatilityChart(ctx, chartManager, timestamp) {
         return a.localeCompare(b);
     });
 
-    orderedKeys.forEach((key) => {
+    for (let i = 0; i < orderedKeys.length; i++) {
+        const key = orderedKeys[i];
         if (transactionState.chartVisibility[key] === undefined) {
             transactionState.chartVisibility[key] = key === '^LZ' || key === '^GSPC';
         }
-    });
+    }
 
     // Transform cumulative TWRR into 90-day annualized rolling volatility
     const allPossibleSeries = orderedKeys.map((key) => {
@@ -265,9 +266,10 @@ export async function drawVolatilityChart(ctx, chartManager, timestamp) {
         return 0;
     });
 
-    seriesForDrawing.forEach((series) => {
+    for (let i = 0; i < seriesForDrawing.length; i++) {
+        const series = seriesForDrawing[i];
         if (series.data.length === 0) {
-            return;
+            continue;
         }
 
         const rawPoints = series.data;
@@ -345,7 +347,7 @@ export async function drawVolatilityChart(ctx, chartManager, timestamp) {
             );
             glowIndex += 1;
         }
-    });
+    }
 
     if (isAnimationEnabled('performance') && glowIndex > 0) {
         schedulePerformanceAnimation(chartManager);
@@ -356,7 +358,8 @@ export async function drawVolatilityChart(ctx, chartManager, timestamp) {
     const showChartLabels = getShowChartLabels();
     const labelBounds = [];
     if (showChartLabels) {
-        renderedSeries.forEach((s) => {
+        for (let i = 0; i < renderedSeries.length; i++) {
+            const s = renderedSeries[i];
             const bounds = drawEndValue(
                 ctx,
                 s.x,
@@ -374,7 +377,7 @@ export async function drawVolatilityChart(ctx, chartManager, timestamp) {
             if (bounds) {
                 labelBounds.push(bounds);
             }
-        });
+        }
     }
 
     chartLayouts.volatility = {


### PR DESCRIPTION
Replaced multiple `.forEach` iteration loops with standard index-based `for` loops in the core chart renderer (`js/transactions/chart/core.js`) and the volatility renderer (`js/transactions/chart/renderers/volatility.js`). This avoids closure allocations per array item, significantly reducing garbage collection pressure inside hot `requestAnimationFrame` loops.

Behaviour unchanged.

`make verify` output:
```
npx --yes eslint . --ext .js
ruff check scripts tests
All checks passed!
npx --yes stylelint "**/*.css"
npx --yes markdownlint "**/*.md" --ignore-path .gitignore
```

---
*PR created automatically by Jules for task [17924880990683075174](https://jules.google.com/task/17924880990683075174) started by @ryusoh*