### PR TITLE
refactor(types): annotate colors.js for strict mode

### DIFF
--- a/js/utils/colors.js
+++ b/js/utils/colors.js
@@ -1,5 +1,9 @@
 import { COLOR_PALETTES } from '@js/config.js';
 
+/**
+ * @param {number} index
+ * @returns {string}
+ */
 export function getBlueColorForSlice(index) {
     // Larger slices (lower index) will get darker blues.
     const palette = COLOR_PALETTES.PIE_CHART_SLICE_COLORS;
@@ -8,6 +12,11 @@ export function getBlueColorForSlice(index) {
     return palette[index % palette.length];
 }
 
+/**
+ * @param {string} hex
+ * @param {number} alpha
+ * @returns {string}
+ */
 export function hexToRgba(hex, alpha) {
     let r = 0,
         g = 0,


### PR DESCRIPTION
TARGET: `js/utils/colors.js`

Strict error count: 87 -> 84

No runtime behavior change. Added JSDoc types for `getBlueColorForSlice` and `hexToRgba`.

Verification output:
```
$ npx tsc -p jsconfig.json --strict 2>&1 | grep '^js/utils/colors.js'
# empty output

$ make verify
npx --yes eslint . --ext .js
ruff check scripts tests
All checks passed!
npx --yes stylelint "**/*.css"
npx --yes markdownlint "**/*.md" --ignore-path .gitignore
python3 -m mypy
Success: no issues found in 1 source file
python3 -m bandit -r scripts -lll
[main]	INFO	profile include tests: None
[main]	INFO	profile exclude tests: None
[main]	INFO	cli include tests: None
[main]	INFO	cli exclude tests: None
[main]	INFO	running on Python 3.12.13
...
Test Suites: 166 passed, 166 total
Tests:       2533 passed, 2533 total
Snapshots:   0 total
Time:        35.241 s
```

---
*PR created automatically by Jules for task [16078155500622163946](https://jules.google.com/task/16078155500622163946) started by @ryusoh*