### PR TITLE
chore(lint): replace markdownlint with markdownlint-cli2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,7 @@ perms:
 lint: js-lint
 	$(PY) -m ruff check scripts tests
 	npx --yes stylelint "**/*.css"
-	npx --yes markdownlint "**/*.md" --ignore-path .gitignore
+	npm exec -- markdownlint-cli2 "**/*.md" "#**/node_modules/**" "#venv/**" "#.qwen/**" "#.claude/**"
 
 fmt:
 	$(PY) -m black .


### PR DESCRIPTION
- Switch from npx markdownlint to npm exec markdownlint-cli2 for improved CLI stability
- Add explicit ignore patterns for node_modules, venv, and AI config directories
- Simplify dependency invocation using npm exec instead of npx --yes